### PR TITLE
added CACHE_BYPASS_COOKIES to customize bypass cookies

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -12,8 +12,14 @@ if ( ! empty($_GET) && ! isset( $_GET['utm_source'], $_GET['utm_medium'], $_GET[
 
 // check cookie values
 if ( !empty($_COOKIE) ) {
+    if ( defined('CACHE_BYPASS_COOKIES') ) {
+        $cookies_regex = CACHE_BYPASS_COOKIES;
+    } else {
+        $cookies_regex = '/^(wp-postpass|wordpress_logged_in|comment_author)_/';
+    }
+
     foreach ( $_COOKIE as $k => $v) {
-        if ( preg_match('/^(wp-postpass|wordpress_logged_in|comment_author)_/', $k) ) {
+        if ( preg_match($cookies_regex, $k) ) {
             return false;
         }
     }

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1258,8 +1258,14 @@ final class Cache_Enabler {
         }
 
         // check cookie values
+        if ( defined('CACHE_BYPASS_COOKIES') ) {
+            $cookies_regex = CACHE_BYPASS_COOKIES;
+        } else {
+            $cookies_regex = '/^(wp-postpass|wordpress_logged_in|comment_author)_/';
+        }
+
         foreach ( $_COOKIE as $k => $v) {
-            if ( preg_match('/^(wp-postpass|wordpress_logged_in|comment_author)_/', $k) ) {
+            if ( preg_match($cookies_regex, $k) ) {
                 return true;
             }
         }


### PR DESCRIPTION
Allow to customize bypass cookies defining a `CACHE_BYPASS_COOKIES` constant on `wp-config.php`.
For example, to add Woocommerce cart cookies:

`define('CACHE_BYPASS_COOKIES', '/^(wp-postpass|wordpress_logged_in|comment_author|woocommerce_items_in_cart|wp_woocommerce_session)_?/');`