### PR TITLE
Update cache_enabler.class.php

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1218,7 +1218,7 @@ final class Cache_Enabler {
     */
 
     private static function _is_index() {
-        return basename($_SERVER['SCRIPT_NAME']) != 'index.php';
+        return strtolower(basename($_SERVER['SCRIPT_NAME'])) != 'index.php';
     }
 
 


### PR DESCRIPTION
Some windows server with plesk defaults return on basename($_SERVER['SCRIPT_NAME']) the "Index.php", whit CAPS.
so _is_index functions fails.