### PR TITLE
Small fixes for settings page

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2054,23 +2054,30 @@ final class Cache_Enabler {
                             <fieldset>
                                 <label for="cache_excl_ids">
                                     <input type="text" name="cache-enabler[excl_ids]" id="cache_excl_ids" value="<?php echo esc_attr($options['excl_ids']) ?>" />
-                                    <p class="description"><?php _e("Post or Pages IDs separated by a <code>,</code> that should not be cached.", "cache-enabler"); ?></p>
+                                    <p class="description">
+                                        <?php echo sprintf(__("Post or Pages IDs separated by a %s that should not be cached.", "cache-enabler"), "<code>,</code>"); ?>
+                                    </p>
                                 </label>
 
                                 <br />
 
                                 <label for="cache_excl_regexp">
                                     <input type="text" name="cache-enabler[excl_regexp]" id="cache_excl_regexp" value="<?php echo esc_attr($options['excl_regexp']) ?>" />
-                                    <p class="description"><?php _e("Regexp matching page paths that should not be cached. e.g. <code>/(^\/$|\/robot\/$|^\/2018\/.*\/test\/)/</code>", "cache-enabler"); ?></p>
+                                    <p class="description">
+                                        <?php _e("Regexp matching page paths that should not be cached.", "cache-enabler"); ?><br>
+                                        <?php _e("Example:", "cache-enabler"); ?> <code>/(^\/$|\/robot\/$|^\/2018\/.*\/test\/)/</code>
+                                    </p>
                                 </label>
 
                                 <br />
 
                                 <label for="cache_excl_cookies">
                                     <input type="text" name="cache-enabler[excl_cookies]" id="cache_excl_cookies" value="<?php echo esc_attr($options['excl_cookies']) ?>" />
-                                    <p class="description"><?php _e("Regexp matching cookies that should cause the cache to be bypassed. <br>
-                                        <nobr>e.g. <code>/^(wp-postpass|wordpress_logged_in|comment_author|(woocommerce_items_in_cart|wp_woocommerce_session)_?)/</code></nobr><br>
-                                        default if unset: <nobr><code>/^(wp-postpass|wordpress_logged_in|comment_author)_/</code></nobr>", "cache-enabler"); ?></p>
+                                    <p class="description">
+                                        <?php _e("Regexp matching cookies that should cause the cache to be bypassed.", "cache-enabler"); ?><br>
+                                        <?php _e("Example:", "cache-enabler"); ?> <code>/^(wp-postpass|wordpress_logged_in|comment_author|(woocommerce_items_in_cart|wp_woocommerce_session)_?)/</code><br>
+                                        <?php _e("Default if unset:", "cache-enabler"); ?> <code>/^(wp-postpass|wordpress_logged_in|comment_author)_/</code>
+                                    </p>
                                 </label>
                             </fieldset>
                         </td>


### PR DESCRIPTION
* Move HTML code out from translatable strings. Follow WP best practices:
https://codex.wordpress.org/I18n_for_WordPress_Developers#Best_Practices

* Don't use <nobr> tag. It's useless and it breaks WP admin panel on mobile resolutions.
before: http://oi66.tinypic.com/2ltijqb.jpg
after:  http://oi66.tinypic.com/5mjwk8.jpg

* Make changed code more readable.