### PR TITLE
Fix bug #11

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -159,6 +159,15 @@ final class Cache_Enabler {
                 'process_clear_request'
             )
         );
+        if ( !is_admin() ) {
+            add_action(
+                'admin_bar_menu',
+                array(
+                    __CLASS__,
+                    'register_textdomain'
+                )
+            );
+        }
 
         // admin
         if ( is_admin() ) {


### PR DESCRIPTION
https://github.com/keycdn/cache-enabler/issues/11

Translations from "lang" subdirectory should be loaded in website area ( !is_admin() )
if the user has admin bar enabled. Cache Enabler plugin adds menu items to this bar.