### PR TITLE
Swap array order to enable 'Page specific' as default

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1684,8 +1684,8 @@ final class Cache_Enabler {
         // init variables
         $dropdown_options = '';
         $available_options = array(
-            esc_html__('Completely', 'cache-enabler'),
-            esc_html__('Page specific', 'cache-enabler')
+            esc_html__('Page specific', 'cache-enabler'),
+            esc_html__('Completely', 'cache-enabler')
         );
 
         // set dropdown options


### PR DESCRIPTION
Swap the array order to enable 'Page specific' as the default setting when editing post or page. The use case is a large blog with multiple authors, not everyone remembers or knows to set the default 'Completely' to 'Page specific' when editing a published post or page.  The result is that a cache with thousands of pages that has been pre-warmed (using curl against a sitemap of URIs) can get inadvertently wiped out.  I am proposing that the default be 'Page specific' instead.  Thanks!