### PR TITLE
Cache http and https pages separately

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -463,13 +463,13 @@ final class Cache_Enabler_Disk {
      * get file path
      *
      * @since   1.0.0
-     * @change  1.0.7
+     * @change  1.3.4
      *
      * @return  string  path to the html file
      */
 
     private static function _file_html() {
-        return self::_file_path(). self::FILE_HTML;
+        return self::_file_path(). self::FILE_HTML. "-". $_SERVER['SERVER_PORT'];
     }
 
 
@@ -477,13 +477,13 @@ final class Cache_Enabler_Disk {
      * get gzip file path
      *
      * @since   1.0.1
-     * @change  1.0.7
+     * @change  1.3.4
      *
      * @return  string  path to the gzipped html file
      */
 
     private static function _file_gzip() {
-        return self::_file_path(). self::FILE_GZIP;
+        return self::_file_path(). self::FILE_GZIP. "-". $_SERVER['SERVER_PORT'];
     }
 
 
@@ -491,13 +491,13 @@ final class Cache_Enabler_Disk {
      * get webp file path
      *
      * @since   1.0.7
-     * @change  1.0.7
+     * @change  1.3.4
      *
      * @return  string  path to the webp html file
      */
 
     private static function _file_webp_html() {
-        return self::_file_path(). self::FILE_WEBP_HTML;
+        return self::_file_path(). self::FILE_WEBP_HTML. "-". $_SERVER['SERVER_PORT'];
     }
 
 
@@ -505,13 +505,13 @@ final class Cache_Enabler_Disk {
      * get gzip webp file path
      *
      * @since   1.0.1
-     * @change  1.0.7
+     * @change  1.3.4
      *
      * @return  string  path to the webp gzipped html file
      */
 
     private static function _file_webp_gzip() {
-        return self::_file_path(). self::FILE_WEBP_GZIP;
+        return self::_file_path(). self::FILE_WEBP_GZIP. "-". $_SERVER['SERVER_PORT'];
     }
 
 


### PR DESCRIPTION
A single URI may be served as http or as https content.

In this case, both requests are likely to not serve the same content. The first one will contain many "http" links to website resources whereas the second will point them as https links.

https "mixed content" issue
----------

Before this commit, a page cache was created the first time a URI was requested, and all next requests to this URI were answered with cached content, ignoring scheme. This especially led to "mixed content" issues when the cache contained http content, because a https page was answered with http links to resources.

Recent browsers then refuse to load those http resources leading to broken https website.

How this pull request try to fix this
------------

This commit appends SERVER_PORT to cache file names so http and https pages are cached separately.

Implementation choices
----

SERVER_PORT has been chosen instead of a "http"/"https" token in cache file path for two reasons:
* Detecting http/https is not that easy, especially when running on IIS web server
* Having all variants of a single URI saved in a single folder helps clearing a single-page cache

Possible improvements
---

A private function may be created in order to remove code duplication, and optionally easify the addition of other variants in the future (like SERVER_PROTOCOL, etc).