### PR TITLE
Fix to the webp regex so that URLs such as '/images/foo.jpg' work when the src/url does not include 'http[s]?'

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -284,7 +284,7 @@ final class Cache_Enabler_Disk {
         // create webp supported files
         if ($options['webp']) {
             // magic regex rule
-            $regex_rule = '#(?<=(?:(ref|src|set)=[\"\']))(?:http[s]?[^\"\']+)(\.png|\.jp[e]?g)(?:[^\"\']+)?(?=[\"\')])#';
+            $regex_rule = '#(?<=(?:(ref|src|set)=[\"\']))(?:[^\"\']+)(\.png|\.jp[e]?g)(?:[^\"\']+)?(?=[\"\')])#';
 
             // call the webp converter callback
             $converted_data = preg_replace_callback($regex_rule,'self::_convert_webp',$data);


### PR DESCRIPTION
This way any src URL, such as "/wp-content/uploads/..." or "//example.com/wp-content/uploads" or even "sftp://example.com/wp-content/uploads" will work with the WebP feature.

The problem on our sites was that these URLs were being skipped by the WebP feature. 

This was a very simple fix to just remove the https[s]? from the regular expression.

Thanks for the plugin!