### PR TITLE
Removes .br files (Brotli-compressed static files like index.html.br) when cache is cleared

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -25,8 +25,10 @@ final class Cache_Enabler_Disk {
 
     const FILE_HTML = 'index.html';
     const FILE_GZIP = 'index.html.gz';
+    const FILE_BR = 'index.html.br';
     const FILE_WEBP_HTML = 'index-webp.html';
     const FILE_WEBP_GZIP = 'index-webp.html.gz';
+    const FILE_WEBP_BR = 'index-webp.html.br';
 
 
     /**
@@ -170,8 +172,10 @@ final class Cache_Enabler_Disk {
 
         @unlink($path.self::FILE_HTML);
         @unlink($path.self::FILE_GZIP);
+        @unlink($path.self::FILE_BR);
         @unlink($path.self::FILE_WEBP_HTML);
         @unlink($path.self::FILE_WEBP_GZIP);
+        @unlink($path.self::FILE_WEBP_BR);
     }
 
 


### PR DESCRIPTION
This is a simple feature add to remove .br (Brotli-compressed) versions of cached pages, if they exist, whenever the cache is cleared. The same way the uncompressed html and .gz compressed files are removed.

This commit does not add Brotli compression/creation of .br files. It just removes them. The assumption is that these are being created some other way, outside the plugin (this is what I'm doing).