### PR TITLE
Change to clear_home() so that it unlinks any files matching the glob "index*html*"

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -86,3 +86,10 @@ function cache_autoload($class) {
         );
     }
 }
+
+// Load the WP-CLI command.
+if (defined('WP_CLI') && WP_CLI && class_exists('WP_CLI')) {
+	require_once CE_DIR . '/inc/cache_enabler_cli.class.php';
+
+	WP_CLI::add_command('cache-enabler', 'Cache_Enabler_CLI');
+}

--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Interact with Cache Enabler.
+ */
+class Cache_Enabler_CLI {
+
+	/**
+	 * Clear the page cache.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--ids=<id>]
+	 * : Flush the cache for given post ID(s). Separate multiple IDs with commas.
+	 *
+	 * [--urls=<url>]
+	 * : Flush the cache for the given URL(s). Separate multiple URLs with commas.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * # Flush all page caches
+	 * wp cache-enabler flush
+	 *
+	 * # Flush the cache for object IDs 1, 2, and 3
+	 * wp cache-enabler flush --ids=1,2,3
+	 *
+	 * # Flush the cache for a particular URL
+	 * wp cache-enabler flush --urls=https://example.com/about-us
+	 *
+	 * @alias clear
+	 */
+	public function flush( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'ids'  => '',
+				'urls' => '',
+			)
+		);
+
+		// Flush everything if we aren't given IDs and/or URLs.
+		if ( empty( $assoc_args['ids'] ) && empty( $assoc_args['urls'] ) ) {
+			Cache_Enabler::clear_total_cache();
+
+			return WP_CLI::success( esc_html__( 'The page cache has been flushed.', 'cache-enabler' ) );
+		}
+
+		// Clear specific IDs and/or URLs.
+		array_map( 'Cache_Enabler::clear_page_cache_by_post_id', explode( ',', $assoc_args['ids'] ) );
+		array_map( 'Cache_Enabler::clear_page_cache_by_url', explode( ',', $assoc_args['urls'] ) );
+
+		WP_CLI::success( 'The requested caches have been cleared.', 'cache-enabler' );
+	}
+}

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -349,12 +349,15 @@ final class Cache_Enabler_Disk {
         if ( ! is_dir($dir) ) {
             return;
         }
-
+        
         // get dir data
-        $objects = array_diff(
-            scandir($dir),
-            array('..', '.')
-        );
+		$data_dir = @scandir($dir);
+		if(gettype($data_dir) === 'array') {
+			$objects = array_diff(
+				$data_dir,
+				array('..', '.')
+			);
+		}
 
         if ( empty($objects) ) {
             return;
@@ -368,7 +371,7 @@ final class Cache_Enabler_Disk {
             if ( is_dir($object) ) {
                 self::_clear_dir($object);
             } else {
-                unlink($object);
+                @unlink($object);
             }
         }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -23,6 +23,7 @@ final class Cache_Enabler_Disk {
      * @var    string
      */
 
+    const FILE_GLOB = 'index*html*';
     const FILE_HTML = 'index.html';
     const FILE_GZIP = 'index.html.gz';
     const FILE_WEBP_HTML = 'index-webp.html';
@@ -168,10 +169,7 @@ final class Cache_Enabler_Disk {
             DIRECTORY_SEPARATOR
         );
 
-        @unlink($path.self::FILE_HTML);
-        @unlink($path.self::FILE_GZIP);
-        @unlink($path.self::FILE_WEBP_HTML);
-        @unlink($path.self::FILE_WEBP_GZIP);
+        array_map('unlink', glob($path.self::FILE_GLOB));
     }
 
 


### PR DESCRIPTION
The idea is to only unlink files that exist instead of trying to `@unlink` `FILE_HTML, FILE_GZIP, FILE_WEBP_HTML, FILE_WEBP_GZIP` whether they exist or not.

This also solves the problem that I was originally trying to address in pull request #62. (I'm doing brotli compression of the static cache files.)