### PR TITLE
Minor Fixes

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -46,7 +46,7 @@ if ( !empty($_GET) ) {
     if ( !empty($settings['incl_attributes']) ) {
         $attributes_regex = $settings['incl_attributes'];
     } else {
-        $attributes_regex = '/^utm_(source|medium|campaign|term|content)$/';
+        $attributes_regex = '/^fbclid|utm_(source|medium|campaign|term|content)$/';
     }
     // prevent cache use if there is any GET variable not covered by the campaign tag regex
     if ( sizeof( preg_grep( $attributes_regex, array_keys( $_GET ), PREG_GREP_INVERT ) ) > 0 ) {

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2149,7 +2149,7 @@ final class Cache_Enabler {
                                     <input type="text" name="cache-enabler[excl_cookies]" id="cache_excl_cookies" value="<?php echo esc_attr($options['excl_cookies']) ?>" />
                                     <p class="description">
                                         <?php _e("Regexp matching cookies that should cause the cache to be bypassed.", "cache-enabler"); ?><br>
-                                        <?php _e("Example:", "cache-enabler"); ?> <code>/^(wp-postpass|wordpress_logged_in|comment_author|(woocommerce_items_in_cart|wp_woocommerce_session)_?)/</code><br>
+                                        <?php _e("Example:", "cache-enabler"); ?> <code>/^(wp-postpass|wordpress_logged_in|comment_author|woocommerce_items_in_cart|wp_woocommerce_session_.*)/</code><br>
                                         <?php _e("Default if unset:", "cache-enabler"); ?> <code>/^(wp-postpass|wordpress_logged_in|comment_author)_/</code>
                                     </p>
                                 </label>

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2168,7 +2168,7 @@ final class Cache_Enabler {
                                     <p class="description">
                                         <?php _e("Regexp matching campaign tracking GET attributes that should not cause the cache to be bypassed.", "cache-enabler"); ?><br>
                                         <?php _e("Example:", "cache-enabler"); ?> <code>/^pk_(source|medium|campaign|kwd|content)$/</code><br>
-                                        <?php _e("Default if unset:", "cache-enabler"); ?> <code>/^utm_(source|medium|campaign|term|content)$/</code>
+                                        <?php _e("Default if unset:", "cache-enabler"); ?> <code>/^fbclid|utm_(source|medium|campaign|term|content)$/</code>
                                     </p>
                                 </label>
                             </fieldset>


### PR DESCRIPTION
Hi, as you know Facebook adds "fbclid" get parameter to all urls that cause cache to be bypassed, I thought it would be good idea to ignore "fbclid" parameter by default.
also i have modified cache exclusion example which was incorrect!
