### PR TITLE
fix function definition for on_upgrade_hook

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -141,7 +141,9 @@ final class Cache_Enabler {
             array(
                 __CLASS__,
                 'on_upgrade_hook',
-            )
+            ),
+            10,
+            2
         );
 
         // act on WooCommerce actions
@@ -409,7 +411,7 @@ final class Cache_Enabler {
      * @change  1.2.3
      */
 
-    public static function on_upgrade_hook( $options ) {
+    public static function on_upgrade_hook( $obj, $options ) {
 
         // clear cache if a plugin has been updated
         if ( self::$options['clear_on_upgrade'] ) {


### PR DESCRIPTION
It appears that #84 accidentally broke the post-upgrade hook, causing a critical error.
[The `upgrader_process_complete` action accepts two arguments](https://developer.wordpress.org/reference/hooks/upgrader_process_complete/): the `WP_Upgrader` instance and an array of extra data. In the refactoring, the `WP_Upgrader` instance was removed, resulting in errors like:
> Uncaught Error: Cannot use object of type SomePlugin as array in /path/to/wp-content/plugins/cache-enabler/inc/cache_enabler.class.php:420

This PR reverts that part of the refactoring, ensuring the proper arguments are passed to `on_upgrade_hook`.