### PR TITLE
update handling of trailing slash and advcache

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -38,7 +38,7 @@ define( 'CE_FILE', __FILE__ );
 define( 'CE_DIR', dirname( __FILE__ ) );
 define( 'CE_BASE', plugin_basename( __FILE__ ) );
 define( 'CE_CACHE_DIR', WP_CONTENT_DIR . '/cache/cache-enabler' );
-define( 'CE_MIN_WP', '4.1' );
+define( 'CE_MIN_WP', '4.6' );
 
 // hooks
 add_action(

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -91,7 +91,7 @@ final class Cache_Enabler_Disk {
 
     public static function check_expiry() {
 
-        // Cache Enabler options
+        // get Cache Enabler options
         $options = Cache_Enabler::$options;
 
         // check if an expiry time is set
@@ -257,16 +257,16 @@ final class Cache_Enabler_Disk {
 
     private static function _create_files( $data ) {
 
-        // create folder
-        if ( ! wp_mkdir_p( self::_file_path() ) ) {
-            wp_die( 'Unable to create directory.' );
-        }
+        // get Cache Enabler options
+        $options = Cache_Enabler::$options;
 
         // get base signature
         $cache_signature = self::_cache_signature();
 
-        // Cache Enabler options
-        $options = Cache_Enabler::$options;
+        // create folder
+        if ( ! wp_mkdir_p( self::_file_path() ) ) {
+            wp_die( 'Unable to create directory.' );
+        }
 
         // create files
         self::_create_file( self::_file_html(), $data . $cache_signature . ' (html) -->' );
@@ -339,12 +339,12 @@ final class Cache_Enabler_Disk {
         // remove slashes
         $dir = untrailingslashit( $dir );
 
-        // check if dir
+        // check if directory
         if ( ! is_dir( $dir ) ) {
             return;
         }
 
-        // get dir data
+        // get directory data
         $data_dir = @scandir( $dir );
         if( gettype( $data_dir ) === 'array' ) {
             $objects = array_diff(
@@ -353,6 +353,7 @@ final class Cache_Enabler_Disk {
             );
         }
 
+        // check if empty
         if ( empty( $objects ) ) {
             return;
         }
@@ -389,12 +390,12 @@ final class Cache_Enabler_Disk {
 
     public static function cache_size( $dir = '.' ) {
 
-        // check if not dir
+        // check if not directory
         if ( ! is_dir( $dir ) ) {
             return;
         }
 
-        // get dir data
+        // get directory data
         $objects = array_diff(
             scandir( $dir ),
             array( '..', '.' )
@@ -410,7 +411,7 @@ final class Cache_Enabler_Disk {
             // full path
             $object = $dir . DIRECTORY_SEPARATOR . $object;
 
-            // check if dir
+            // check if directory
             if ( is_dir( $object ) ) {
                 $size += self::cache_size( $object );
             } else {
@@ -432,7 +433,7 @@ final class Cache_Enabler_Disk {
      * @return  string  $diff  path to cached file
      */
 
-    private static function _file_path( $path = NULL ) {
+    private static function _file_path( $path = null ) {
 
         $path = sprintf(
             '%s%s%s%s',
@@ -546,8 +547,6 @@ final class Cache_Enabler_Disk {
      *
      * @since   1.2.3
      * @change  1.2.3
-     *
-     * @return void
      */
 
     private static function _write_settings( $settings_file, $settings ) {
@@ -597,13 +596,13 @@ final class Cache_Enabler_Disk {
      * delete settings for advanced-cache.php
      *
      * @since   1.2.3
-     * @change  1.2.3
+     * @change  1.4.0
      *
-     * @param   array    settings as array or empty for delete all
+     * @param   array    settings keys as array or empty for delete all
      * @return  boolean  true if successful
      */
 
-    public static function delete_advcache_settings( $remsettings = array() ) {
+    public static function delete_advcache_settings( $settings_keys = array() ) {
 
         $settings_file = sprintf(
             '%s-%s%s.json',
@@ -615,18 +614,18 @@ final class Cache_Enabler_Disk {
             is_multisite() ? '-' . get_current_blog_id() : ''
         );
 
-        if ( ! file_exists( $settings_file ) || empty( $remsettings ) ) {
+        if ( ! file_exists( $settings_file ) ) {
             return true;
         }
 
         $settings = self::_read_settings( $settings_file );
-        foreach ( $remsettings as $key ) {
+        foreach ( $settings_keys as $key ) {
             if ( array_key_exists( $key, $settings ) ) {
                 unset( $settings[ $key ] );
             }
         }
 
-        if ( empty( $settings ) ) {
+        if ( empty( $settings ) || empty( $settings_keys ) ) {
             unlink( $settings_file );
             return true;
         }
@@ -658,7 +657,6 @@ final class Cache_Enabler_Disk {
         }
 
         return $asset[0];
-
     }
 
 


### PR DESCRIPTION
Update the handling of trailing slashes to allow the cache to be bypassed if the permalink structure is with or without a trailing slash (#85). Set the `permalink_trailing_slash` advanced cache setting to `false` if trailing slash has not been set in the Permalink Settings.

Update settings page save actions to have "Save Changes" and "Save Changes and Clear Cache" buttons. Allows the ability to save the settings without completely clearing the cache. Inspired by the lovely folks working on Autoptimize. This prevents unwanted cache clearing when creating the advanced cache settings file.

Update the `_install_backend()` method to not clear the cache. The cache should not be cleared when installing requirements, like on activation or if a new subsite is added.

Update the `requirements_check()` method to not define `$options` variable because it can be accessed through the default vars. Update `CE_MIN_WP` constant to 4.6.

Update the handling of the advanced cache settings file:

* Add an `create_advcache_settings()` method in the `Cache_Enabler` class to create/update advanced cache settings file when required.

* Add action for `permalink_structure_changed` hook to call `create_advcache_settings()` when permalink structure has been changed. This is required to update the `permalink_trailing_slash` advanced cache setting.

* Update `on_activation()` and `on_deactivation()` methods to create advanced cache settings file(s) on activation and delete the same file(s) on deactivation. Previously the advanced cache settings file(s) would not be generated until the Cache Enabler settings were saved. This led to the rare case where pages without a trailing slash were not redirecting (#85). Use hook activation and deactivation `$network_wide` value to determine if network activated.

* Update `on_upgrade_hook()` method to update Cache Enabler requirements and clear the cache if Cache Enabler has been updated.

* Fix the `delete_advcache_settings()` method to actually delete all advanced cache settings if empty.

Fix advanced cache file not unlinking on plugin deactivation by updating the `clear_total_cache()` method to not update the advanced cache file. This is only required when the Cache Enabler plugin is updated.

Fix how WooCommerce is being checked if active so the product stock Cache Behavior setting is visible even when network activated.

Fix `on_uninstall()` to actually uninstall on each subsite if network activated. Previously only the main site was being uninstalled. Using `$_GET['networkwide']` is not an available attribute when Cache Enabler is uninstalled (deleted) so it always returns false. For uninstalling on multisites only checking `is_multisite()` is required because plugins must be deleted from the network admin.

Extend the Cache Behavior by allowing the cache to be completely cleared if a plugin has also been activated or deactivated in addition to being updated (#86).

Fixes #85
Closes #86