### PR TITLE
fix advcache and update advcache settings

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -120,7 +120,6 @@ final class Cache_Enabler {
             // warnings and notices
             add_action( 'admin_notices', array( __CLASS__, 'warning_is_permalink' ) );
             add_action( 'admin_notices', array( __CLASS__, 'requirements_check' ) );
-
         // caching hooks
         } else {
             // comments
@@ -296,6 +295,8 @@ final class Cache_Enabler {
 
         // delete advanced cache settings file(s) and clear complete cache
         self::on_ce_activation_deactivation( 'deactivated', $network_wide );
+        // decom old advanced cache settings file(s) (1.4.0)
+        array_map( 'unlink', glob( WP_CONTENT_DIR . '/cache/cache-enabler-advcache-*.json' ) );
 
         // create advanced cache settings file(s)
         self::on_ce_activation_deactivation( 'activated', $network_wide );
@@ -384,7 +385,7 @@ final class Cache_Enabler {
 
     public static function on_uninstall() {
 
-        // network activated
+        // network
         if ( is_multisite() ) {
             // blog IDs
             $ids = self::_get_blog_ids();
@@ -467,7 +468,7 @@ final class Cache_Enabler {
             $wp_config = file( $wp_config_file );
 
             if ( $wp_cache_value ) {
-                $wp_cache_ce_line = "define('WP_CACHE', true); // Added by Cache Enabler". "\r\n";
+                $wp_cache_ce_line = "define('WP_CACHE', true); // Added by Cache Enabler" . "\r\n";
             } else {
                 $wp_cache_ce_line = '';
             }
@@ -1874,7 +1875,7 @@ final class Cache_Enabler {
         if ( $permalink_structure && preg_match( '/\/$/', $permalink_structure ) ) {
             // record permalink structure has trailing slash for advanced cache
             Cache_Enabler_Disk::record_advcache_settings( array(
-                    'permalink_trailing_slash' => true,
+                'permalink_trailing_slash' => true,
             ) );
             // if trailing slash is missing, check if we have to bypass the cache to allow a redirect
             if ( ! preg_match( '/\/(|\?.*)$/', $_SERVER['REQUEST_URI'] ) ) {
@@ -1883,7 +1884,7 @@ final class Cache_Enabler {
         } else {
             // record permalink structure does not have trailing slash for advanced cache
             Cache_Enabler_Disk::record_advcache_settings( array(
-                    'permalink_trailing_slash' => false,
+                'permalink_trailing_slash' => false,
             ) );
             // if trailing slash is appended, check if we have to bypass the cache to allow a redirect
             if ( preg_match( '/(?!^)\/(|\?.*)$/', $_SERVER['REQUEST_URI'] ) ) {
@@ -2172,7 +2173,6 @@ final class Cache_Enabler {
                 <input name="cache-enabler[clear_cache]" type="submit" class="button-primary" value="<?php esc_html_e( 'Save Changes and Clear Cache', 'cache-enabler' ); ?>" />
                 </p>
             </form>
-            <p><?php esc_html_e( 'It is recommended to enable HTTP/2 on your origin server and use a CDN that supports HTTP/2. Avoid domain sharding and concatenation of your assets to benefit from parallelism of HTTP/2.', 'cache-enabler' ); ?></p>
         </div>
 
         <?php

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -518,12 +518,52 @@ final class Cache_Enabler_Disk {
 
 
     /**
+     * get settings file
+     *
+     * @since   1.4.0
+     * @change  1.4.0
+     *
+     * @return  string  settings file path
+     */
+
+    private static function _get_settings() {
+
+        // network with subdirectory configuration
+        if ( is_multisite() && ! is_subdomain_install() ) {
+            // get blog path
+            $path = trim( get_blog_details( get_current_blog_id() )->path, '/' );
+            // check if subsite
+            if ( ! empty( $path ) ) {
+                $path = '-' . $path;
+            }
+        // single site, network subdirectory main site, or any network subdomain site
+        } else {
+            $path = '';
+        }
+
+        // get settings file
+        $settings_file = sprintf(
+            '%s-%s%s.json',
+            WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache',
+            parse_url(
+                get_site_url(),
+                PHP_URL_HOST
+            ),
+            $path
+        );
+
+        return $settings_file;
+    }
+
+
+    /**
      * read settings file
      *
      * @since   1.2.3
      * @change  1.2.3
      *
-     * @return  array  settings or emtpy
+     * @param   string  $settings_file  settings file path
+     * @return  array                   settings or empty
      */
 
     private static function _read_settings( $settings_file ) {
@@ -547,6 +587,9 @@ final class Cache_Enabler_Disk {
      *
      * @since   1.2.3
      * @change  1.2.3
+     *
+     * @param   string  $settings_file  settings file path
+     * @param   array   $settings       settings
      */
 
     private static function _write_settings( $settings_file, $settings ) {
@@ -567,15 +610,8 @@ final class Cache_Enabler_Disk {
 
     public static function record_advcache_settings( $settings ) {
 
-        $settings_file = sprintf(
-            '%s-%s%s.json',
-            WP_CONTENT_DIR . '/cache/cache-enabler-advcache',
-            parse_url(
-                get_site_url(),
-                PHP_URL_HOST
-            ),
-            is_multisite() ? '-' . get_current_blog_id() : ''
-        );
+        // get settings file
+        $settings_file = self::_get_settings();
 
         // create folder if neccessary
         if ( ! wp_mkdir_p( dirname( $settings_file ) ) ) {
@@ -604,16 +640,10 @@ final class Cache_Enabler_Disk {
 
     public static function delete_advcache_settings( $settings_keys = array() ) {
 
-        $settings_file = sprintf(
-            '%s-%s%s.json',
-            WP_CONTENT_DIR . '/cache/cache-enabler-advcache',
-            parse_url(
-                get_site_url(),
-                PHP_URL_HOST
-            ),
-            is_multisite() ? '-' . get_current_blog_id() : ''
-        );
+        // get settings file
+        $settings_file = self::_get_settings();
 
+        // check if settings file exists
         if ( ! file_exists( $settings_file ) ) {
             return true;
         }


### PR DESCRIPTION
Fix how the advanced cache reads the advanced cache settings files for multisite networks. Previously `$blog_id` would return `1` in all cases (regardless of the actual current blog ID). Obtaining the correct current blog ID without loading many requirements is not possible (that is even if that would work). Instead of using the blog ID let us use the blog domain for subdomain configurations and the blog path for subdirectory configurations.

Update the directory that stores the advanced cache settings file(s). Move from `wp-content/cache` to `wp-content/plugins/cache-enabler/settings` because settings files should not be stored in a `cache` directory.

Remove HTTP/2 recommendation from settings page.