### PR TITLE
add scheme-based caching

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -18,11 +18,12 @@ final class Cache_Enabler_Disk {
      * cached filename settings
      *
      * @since   1.0.7
-     * @change  1.0.7
+     * @change  1.4.0
      *
      * @var     string
      */
 
+    const FILE_GLOB      = '*index*';
     const FILE_HTML      = 'index.html';
     const FILE_GZIP      = 'index.html.gz';
     const FILE_WEBP_HTML = 'index-webp.html';
@@ -149,7 +150,7 @@ final class Cache_Enabler_Disk {
      * clear home cache
      *
      * @since   1.0.7
-     * @change  1.0.9
+     * @change  1.4.0
      */
 
     public static function clear_home() {
@@ -162,10 +163,7 @@ final class Cache_Enabler_Disk {
             DIRECTORY_SEPARATOR
         );
 
-        @unlink( $path . self::FILE_HTML );
-        @unlink( $path . self::FILE_GZIP );
-        @unlink( $path . self::FILE_WEBP_HTML );
-        @unlink( $path . self::FILE_WEBP_GZIP );
+        array_map( 'unlink', glob( $path . self::FILE_GLOB ) );
     }
 
 
@@ -250,7 +248,7 @@ final class Cache_Enabler_Disk {
      * create files
      *
      * @since   1.0.0
-     * @change  1.1.1
+     * @change  1.4.0
      *
      * @param   string  $data  HTML content
      */
@@ -269,11 +267,11 @@ final class Cache_Enabler_Disk {
         }
 
         // create files
-        self::_create_file( self::_file_html(), $data . $cache_signature . ' (html) -->' );
+        self::_create_file( self::_file_html(), $data . $cache_signature . ' (' . self::_file_scheme() . ' html) -->' );
 
         // create pre-compressed file
         if ( $options['compress'] ) {
-            self::_create_file( self::_file_gzip(), gzencode( $data . $cache_signature . ' (html gzip) -->', 9) );
+            self::_create_file( self::_file_gzip(), gzencode( $data . $cache_signature . ' (' . self::_file_scheme() . ' gzip) -->', 9) );
         }
 
         // create webp supported files
@@ -284,11 +282,11 @@ final class Cache_Enabler_Disk {
             // call the webp converter callback
             $converted_data = apply_filters( 'cache_enabler_disk_webp_converted_data', preg_replace_callback( $regex_rule, 'self::_convert_webp', $data ) );
 
-            self::_create_file( self::_file_webp_html(), $converted_data . $cache_signature . ' (webp) -->' );
+            self::_create_file( self::_file_webp_html(), $converted_data . $cache_signature . ' (' . self::_file_scheme() . ' webp html) -->' );
 
             // create pre-compressed file
             if ( $options['compress'] ) {
-                self::_create_file( self::_file_webp_gzip(), gzencode( $converted_data . $cache_signature . ' (webp gzip) -->', 9) );
+                self::_create_file( self::_file_webp_gzip(), gzencode( $converted_data . $cache_signature . ' (' . self::_file_scheme() . ' webp gzip) -->', 9) );
             }
         }
     }
@@ -458,17 +456,43 @@ final class Cache_Enabler_Disk {
 
 
     /**
+     * get file scheme
+     *
+     * @since   1.4.0
+     * @change  1.4.0
+     *
+     * @return  string  https, http, or port
+     */
+
+    private static function _file_scheme() {
+
+        // https
+        if ( $_SERVER['SERVER_PORT'] === '443' ) {
+            return 'https';
+        }
+
+        // http
+        if ( $_SERVER['SERVER_PORT'] === '80' ) {
+            return 'http';
+        }
+
+        // port
+        return $_SERVER['SERVER_PORT'];
+    }
+
+
+    /**
      * get file path
      *
      * @since   1.0.0
-     * @change  1.0.7
+     * @change  1.4.0
      *
      * @return  string  path to the HTML file
      */
 
     private static function _file_html() {
 
-        return self::_file_path() . self::FILE_HTML;
+        return self::_file_path() . self::_file_scheme() . '-' . self::FILE_HTML;
     }
 
 
@@ -476,14 +500,14 @@ final class Cache_Enabler_Disk {
      * get gzip file path
      *
      * @since   1.0.1
-     * @change  1.0.7
+     * @change  1.4.0
      *
      * @return  string  path to the gzipped HTML file
      */
 
     private static function _file_gzip() {
 
-        return self::_file_path() . self::FILE_GZIP;
+        return self::_file_path() . self::_file_scheme() . '-' . self::FILE_GZIP;
     }
 
 
@@ -491,14 +515,14 @@ final class Cache_Enabler_Disk {
      * get webp file path
      *
      * @since   1.0.7
-     * @change  1.0.7
+     * @change  1.4.0
      *
      * @return  string  path to the webp HTML file
      */
 
     private static function _file_webp_html() {
 
-        return self::_file_path() . self::FILE_WEBP_HTML;
+        return self::_file_path() . self::_file_scheme() . '-' . self::FILE_WEBP_HTML;
     }
 
 
@@ -506,14 +530,14 @@ final class Cache_Enabler_Disk {
      * get gzip webp file path
      *
      * @since   1.0.1
-     * @change  1.0.7
+     * @change  1.4.0
      *
      * @return  string  path to the webp gzipped HTML file
      */
 
     private static function _file_webp_gzip() {
 
-        return self::_file_path() . self::FILE_WEBP_GZIP;
+        return self::_file_path() . self::_file_scheme() . '-' . self::FILE_WEBP_GZIP;
     }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,16 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.4.0 =
+* Update default cache behavior for WooCommerce stock update
+* Update default publishing action
+* Update settings page
+* Update Cache Behavior setting for plugin actions
+* Add scheme-based caching
+* Add Cache Behavior setting for WooCommerce stock update
+* Fix multisite advanced cache settings
+* Fix minor bugs
+
 = 1.3.5 =
 * WP-CLI cache clearing (Thanks to Steve Grunwell)
 * Added cache_enabler_disk_webp_converted_data filter


### PR DESCRIPTION
Cache HTTP and HTTPS pages separately (#20). This builds upon PR #50. This fixes HTTP resources being requested by a page that is loaded over HTTPS. This occurs when a page is loaded over HTTP, cached, and then later loaded over HTTPS. This also fixes HTTPS resources being requested by a page that is loaded over HTTP. If the website does not have a valid SSL/TLS certificate the requests would fail. This issue can arise when HTTP or HTTPS is not being forced.

Update Cache Enabler HTML comment to be more clear on what cached page is being delivered.

Update `clear_home()` method to unlink based on glob pattern. This builds upon part of PR #64. This is a better way to clear the home page cache as we are not attempting to unlink files that do not exist. Further, this makes clearing the home page cache more simple when introducing scheme-based caching.

Fixes #20