### PR TITLE
update cache behavior for logged in users

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1262,24 +1262,6 @@ final class Cache_Enabler {
 
 
     /**
-     * check if logged in
-     *
-     * @since   1.0.0
-     * @change  1.4.0
-     *
-     * @return  boolean  true if logged in
-     */
-
-    private static function _is_logged_in() {
-
-        // check if logged in
-        if ( is_user_logged_in() ) {
-            return true;
-        }
-    }
-
-
-    /**
      * check if there are posts to be published in the future
      *
      * @since   1.2.3
@@ -1335,11 +1317,6 @@ final class Cache_Enabler {
 
         // check DONOTCACHEPAGE
         if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {
-            return true;
-        }
-
-        // check if logged in
-        if ( self::_is_logged_in() ) {
             return true;
         }
 


### PR DESCRIPTION
Allow cached pages to be delivered to logged in users (#19). Remove the `_is_logged_in()` method and instead allow the cookies Cache Exclusion to control this. This was already the current behavior when a page had already been cached as the advanced cache is only checking the cookie names. By default the cookies Cache Exclusion setting will bypass the cache when logged in.

If a certain user role needs to be bypassed a custom cookie, such as `user_admin=1`, can be set. The cookies Cache Exclusion option can then be updated (e.g. `/user_admin/`). This can be done in many different ways, one being a custom function in the `functions.php` file that uses `wp_get_current_user()` and `setcookie()`, for example:

```
$user = wp_get_current_user();
if ( in_array( 'Administrator', (array) $user->roles ) ) {
    setcookie( 'user_admin', 1 );
}
```

Closes #19