### PR TITLE
update cache clearing

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Cache Enabler advanced cache
+ *
+ * @since   1.2.0
+ * @change  1.4.0
+ */
 
 // check if request method is GET
 if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || $_SERVER['REQUEST_METHOD'] !== 'GET' ) {
@@ -22,7 +28,7 @@ if ( ! is_readable( $path_html ) ) {
 // check if there are settings
 $settings_file = sprintf(
     '%s-%s%s.json',
-    WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache',
+    CE_SETTINGS_PATH,
     parse_url(
         'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
         PHP_URL_HOST

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -38,7 +38,8 @@ define( 'CE_FILE', __FILE__ );
 define( 'CE_DIR', dirname( __FILE__ ) );
 define( 'CE_BASE', plugin_basename( __FILE__ ) );
 define( 'CE_CACHE_DIR', WP_CONTENT_DIR . '/cache/cache-enabler' );
-define( 'CE_MIN_WP', '4.6' );
+define( 'CE_SETTINGS_PATH', WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache' );
+define( 'CE_MIN_WP', '5.1' );
 
 // hooks
 add_action(

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -142,6 +142,7 @@ final class Cache_Enabler_Disk {
 
     public static function clear_cache() {
 
+        // clear complete cache
         self::_clear_dir( CE_CACHE_DIR );
     }
 
@@ -425,7 +426,7 @@ final class Cache_Enabler_Disk {
      * cache path
      *
      * @since   1.0.0
-     * @change  1.1.0
+     * @change  1.4.0
      *
      * @param   string  $path  URI or permalink
      * @return  string  $diff  path to cached file
@@ -438,7 +439,7 @@ final class Cache_Enabler_Disk {
             CE_CACHE_DIR,
             DIRECTORY_SEPARATOR,
             parse_url(
-                'http://' .strtolower( $_SERVER['HTTP_HOST'] ),
+                get_site_url(),
                 PHP_URL_HOST
             ),
             parse_url(
@@ -555,7 +556,7 @@ final class Cache_Enabler_Disk {
         // network with subdirectory configuration
         if ( is_multisite() && ! is_subdomain_install() ) {
             // get blog path
-            $path = trim( get_blog_details( get_current_blog_id() )->path, '/' );
+            $path = trim( get_blog_details()->path, '/' );
             // check if subsite
             if ( ! empty( $path ) ) {
                 $path = '-' . $path;
@@ -568,11 +569,8 @@ final class Cache_Enabler_Disk {
         // get settings file
         $settings_file = sprintf(
             '%s-%s%s.json',
-            WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache',
-            parse_url(
-                get_site_url(),
-                PHP_URL_HOST
-            ),
+            CE_SETTINGS_PATH,
+            Cache_Enabler::get_blog_domain(),
             $path
         );
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Cache Enabler - WordPress Cache ===
 Contributors: keycdn
 Tags: cache, caching, wordpress cache, wp cache, performance, gzip, webp, http2
-Requires at least: 4.6
-Tested up to: 5.4
+Requires at least: 5.1
+Tested up to: 5.5
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -63,7 +63,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = System Requirements =
 * PHP >=5.6
-* WordPress >=4.6
+* WordPress >=5.1
 
 
 = Contribute =
@@ -83,12 +83,17 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.4.0 =
 * Update default cache behavior for WooCommerce stock update
-* Update default publishing action
-* Update settings page
 * Update Cache Behavior setting for plugin actions
-* Add scheme-based caching
+* Update admin bar clear cache buttons
+* Update cache behavior for logged in users
+* Update default clear cache publishing action
+* Update advanced cache settings
+* Update trailing slash handling
+* Update settings page
 * Add Cache Behavior setting for WooCommerce stock update
-* Fix multisite advanced cache settings
+* Add fbclid as default URL query parameter to bypass cache
+* Add scheme-based caching
+* Fix advanced cache for multisite networks
 * Fix minor bugs
 
 = 1.3.5 =


### PR DESCRIPTION
Update `wpmu_new_blog` action hook with `wp_initialize_site` because it has been deprecated since WordPress version 5.1.0. Update `delete_blog` action hook with `wp_uninitialize_site` because it has been deprecated since WordPress version 5.1.0. This makes the new minimum WordPress version 5.1. Update the `CE_MIN_WP` constant to 5.1.

Update `Cache_Enabler::on_ce_activation_deactivation()` to only clear the complete cache once.

Update `Cache_Enabler::on_uninstall()` to clear the complete cache instead of `Cache_Enabler::_uninstall_backend()`. This avoids unnecessarily clearing the complete cache multiple times when Cache Enabler in uninstalled on a network installation.

Update `Cache_Enabler::uninstall_later()`:

* Do not use the `switch_to_blog()` function because switching to a blog that has been deleted will not work.

* Only clear the complete cache of the deleted site in the network instead of the complete cache.

* Remove `Cache_Enabler::_uninstall_backend()` because the table with the Cache Enabler option is dropped when a site is deleted.

Update clear request processing:

* Update the "Clear Cache" admin bar button to be "Clear Network Cache" if on network admin interface.

* Clear the complete network cache if performed from network admin interface. Previously only the main site cache would be cleared.

* Update the clear request URL query parameters naming to improve understanding of functionality.

* Add clear ID to check and prevent the same clear request from processing twice. This is done by adding a unix timestamp as a URL query parameter and setting a cookie with that timestamp. If the timestamp in the URL matches the cookie value before being set then the request is not processed. Previously the clear request could be processed on a page refresh until the nonce expired, which could lead to unwanted clear requests.

* Fix cache clearing behavior on a multisite network with the subdirectory configuration. Previously when the "Clear Cache" admin bar button was clicked the complete network cache would be cleared. Now only the specific site cache will be cleared. This was already the current behavior on a multisite network with the subdomain configuration.

Update type validations to use `is_int()` and `is_string()` to improve code readability (e.g. instead of `! $var = (string) $var`).

Update `Cache_Enabler_Disk::_file_path()` to use `get_site_url()`. This is required to properly clear the cache by URL when installed on a network installation. Previously when network activated and a new site was created the hostname of the network admin was used instead of the current blog.

Add `CE_SETTINGS_PATH` constant for advanced cache settings file path.

Add `Cache_Enabler::clear_blog_id_cache()` to clear the complete cache of a blog in a network installation by the blog ID (for both subdomain and subdirectory configurations).

Add `Cache_Enabler::get_blog_domain()` so both `Cache_Enabler_Disk::_get_settings()` and `Cache_Enabler::clear_blog_id_cache()` use the same method to get the blog domain.