### PR TITLE
update clear requests and fix advcache

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -14,11 +14,14 @@ if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || $_SERVER['REQUEST_METHOD'] !== 'GE
 // base path
 $path = _ce_file_path();
 
+// scheme
+$scheme = ( ( isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTPS'] ) ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
+
 // path to cached variants
-$path_html      = $path . 'index.html';
-$path_gzip      = $path . 'index.html.gz';
-$path_webp_html = $path . 'index-webp.html';
-$path_webp_gzip = $path . 'index-webp.html.gz';
+$path_html      = $path . $scheme . '-index.html';
+$path_gzip      = $path . $scheme . '-index.html.gz';
+$path_webp_html = $path . $scheme . '-index-webp.html';
+$path_webp_gzip = $path . $scheme . '-index-webp.html.gz';
 
 // check if cached file exists
 if ( ! is_readable( $path_html ) ) {
@@ -28,7 +31,7 @@ if ( ! is_readable( $path_html ) ) {
 // check if there are settings
 $settings_file = sprintf(
     '%s-%s%s.json',
-    CE_SETTINGS_PATH,
+    WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache',
     parse_url(
         'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
         PHP_URL_HOST
@@ -157,7 +160,7 @@ function _ce_file_path( $path = null ) {
         WP_CONTENT_DIR . '/cache/cache-enabler',
         DIRECTORY_SEPARATOR,
         parse_url(
-            'http://' .strtolower( $_SERVER['HTTP_HOST'] ),
+            'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
             PHP_URL_HOST
         ),
         parse_url(

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -35,7 +35,6 @@ define( 'CE_FILE', __FILE__ );
 define( 'CE_DIR', dirname( __FILE__ ) );
 define( 'CE_BASE', plugin_basename( __FILE__ ) );
 define( 'CE_CACHE_DIR', WP_CONTENT_DIR . '/cache/cache-enabler' );
-define( 'CE_SETTINGS_PATH', WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache' );
 define( 'CE_MIN_WP', '5.1' );
 
 // hooks

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -909,7 +909,7 @@ final class Cache_Enabler {
             } else {
                 if ( $_GET['_action'] === 'clearurl' ) {
                     // clear specific site URL cache
-                    self::clear_page_cache_by_url( $clear_url );
+                    self::process_clear_request_url( $clear_url );
                 } elseif ( $_GET['_action'] === 'clear' ) {
                     // clear specific site complete cache
                     self::clear_blog_id_cache( get_current_blog_id() );
@@ -930,7 +930,7 @@ final class Cache_Enabler {
         } else {
             if ( $_GET['_action'] === 'clearurl' ) {
                 // clear URL cache
-                self::clear_page_cache_by_url( $clear_url );
+                self::process_clear_request_url( $clear_url );
             } elseif ( $_GET['_action'] === 'clear' ) {
                 // clear complete cache
                 self::clear_total_cache();
@@ -957,6 +957,29 @@ final class Cache_Enabler {
             );
 
             exit();
+        }
+    }
+
+
+    /**
+     * process clear request URL
+     *
+     * @since   1.4.2
+     * @change  1.4.2
+     *
+     * @param   string  $clear_url  URL to be processed
+     */
+
+    public static function process_clear_request_url( $clear_url ) {
+
+        // get home page URL
+        $home_page_url = get_site_url( null, '/' );
+
+        // check clear URL
+        if ( $clear_url === $home_page_url ) {
+            self::clear_home_page_cache();
+        } else {
+            self::clear_page_cache_by_url( $clear_url );
         }
     }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -467,18 +467,7 @@ final class Cache_Enabler_Disk {
 
     private static function _file_scheme() {
 
-        // https
-        if ( $_SERVER['SERVER_PORT'] === '443' ) {
-            return 'https';
-        }
-
-        // http
-        if ( $_SERVER['SERVER_PORT'] === '80' ) {
-            return 'http';
-        }
-
-        // port
-        return $_SERVER['SERVER_PORT'];
+        return ( ( isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTPS'] ) ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
     }
 
 
@@ -569,7 +558,7 @@ final class Cache_Enabler_Disk {
         // get settings file
         $settings_file = sprintf(
             '%s-%s%s.json',
-            CE_SETTINGS_PATH,
+            WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache',
             Cache_Enabler::get_blog_domain(),
             $path
         );

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,11 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.4.2 =
+* Update cache clearing for the Clear URL Cache admin bar button
+* Update scheme-based caching
+* Fix advanced cache
+
 = 1.4.1 =
 * Fix minor bugs
 


### PR DESCRIPTION
Update `Cache_Enabler::process_clear_request()` to only clear the home page cache when using the "Clear URL Cache" admin bar button on the home page. Previously the complete cache would be cleared.

Fix advanced cache path to cached variants. This allows the advanced cache to deliver the cached page and bypass PHP as it did in version 1.3.5. This should have been done in PR #94.

Delete `CE_SETTINGS_PATH` constant that was added in PR #96. The advanced cache is not always able to read the value of this constant.