### PR TITLE
update cache clearing and advcache settings

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -3,7 +3,7 @@
  * Cache Enabler advanced cache
  *
  * @since   1.2.0
- * @change  1.4.0
+ * @change  1.4.2
  */
 
 // check if request method is GET

--- a/readme.txt
+++ b/readme.txt
@@ -81,13 +81,17 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.4.3 =
+* Update URL cache clearing
+* Update advcache settings
+
 = 1.4.2 =
 * Update cache clearing for the Clear URL Cache admin bar button
 * Update scheme-based caching
 * Fix advanced cache
 
 = 1.4.1 =
-* Fix minor bugs
+* Fix undefined constant
 
 = 1.4.0 =
 * Update default cache behavior for WooCommerce stock update


### PR DESCRIPTION
Merge `Cache_Enabler::process_clear_request_url()` with `Cache_Enabler::clear_page_cache_by_url()`. Unsure why I added this new method in PR #98 when it would be better to check the URL when clearing the cache by URL instead. This is better because it ensures the complete cache is not cleared if the home page URL is cleared. This fixes the issue where the complete cache was cleared if the post ID passed in `Cache_Enabler::clear_page_cache_by_post_id()` was the home page.

Split `Cache_Enabler::handle_trailing_slash()` into `Cache_Enabler::_bypass_cache_for_trailing_slash()` (new) and `Cache_Enabler::validate_settings()` (existing) to avoid updating the advanced cache settings file(s) unnecessarily (#97). Add `Cache_Enabler::permalink_structure_has_trailing_slash()` to check if the permalink structure has a trailing slash.

Update `Cache_Enabler::handle_cache()`. Move checking if the trailing slash should be bypassed to `Cache_Enabler::_bypass_cache()` instead to run all bypass checks in one method.

Closes #97