### PR TITLE
update WP_CACHE handling and fix cache handling

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -164,7 +164,7 @@ function _ce_file_path( $path = null ) {
             PHP_URL_HOST
         ),
         parse_url(
-            ( $path ? $path : $_SERVER['REQUEST_URI'] ),
+            ( $path ) ? $path : $_SERVER['REQUEST_URI'],
             PHP_URL_PATH
         )
     );

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -426,7 +426,7 @@ final class Cache_Enabler_Disk {
      * cache path
      *
      * @since   1.0.0
-     * @change  1.4.0
+     * @change  1.4.5
      *
      * @param   string  $path  URI or permalink
      * @return  string  $diff  path to cached file
@@ -439,11 +439,11 @@ final class Cache_Enabler_Disk {
             CE_CACHE_DIR,
             DIRECTORY_SEPARATOR,
             parse_url(
-                get_site_url(),
+                ( $path ) ? get_site_url() : 'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
                 PHP_URL_HOST
             ),
             parse_url(
-                ( $path ? $path : $_SERVER['REQUEST_URI'] ),
+                ( $path ) ? $path : $_SERVER['REQUEST_URI'],
                 PHP_URL_PATH
             )
         );

--- a/readme.txt
+++ b/readme.txt
@@ -81,17 +81,23 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.4.5 =
+* Update WP_CACHE constant handling (#102)
+* Add cache bypass method for WP_CACHE constant (#102)
+* Add translation descriptions (#102)
+* Fix cache handling for default redirects (#102)
+
 = 1.4.4 =
-* Update cache handling (#100)
+* Update cache handling for HTTP status codes (#100)
 
 = 1.4.3 =
 * Update cache clearing by URL (#99)
-* Update advanced cache settings (#99)
+* Fix advanced cache settings updating unnecessarily (#99)
 
 = 1.4.2 =
 * Update cache clearing for the Clear URL Cache admin bar button (#98)
 * Update scheme-based caching (#98)
-* Fix advanced cache (#98)
+* Fix advanced cache path variants (#98)
 
 = 1.4.1 =
 * Fix undefined constant
@@ -108,7 +114,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 * Add Cache Behavior setting for WooCommerce stock update (#88)
 * Add fbclid as default URL query parameter to bypass cache (#84)
 * Add scheme-based caching (#94)
-* Fix advanced cache for multisite networks (#92)
+* Fix advanced cache settings recognition for multisite networks (#92)
 
 = 1.3.5 =
 * WP-CLI cache clearing (Thanks to Steve Grunwell)


### PR DESCRIPTION
Update `Cache_Enabler::_set_wp_cache()`:

* Only set the `WP_CACHE` constant if it is not found in the `wp-config.php` file. Previously it would overwrite `define( 'WP_CACHE', false );`. If this constant has been set in the `wp-config.php` file the Cache Enabler plugin should not overwrite it because this would have been explicitly set. A notice is still given to inform caching is disabled.

* Only remove the `WP_CACHE` constant if it was added by Cache Enabler. Previously it would always remove the `WP_CACHE` constant if it was defined as `true`. If this constant was not set in the `wp-config.php` file by Cache Enabler then we should not remove it.

Fix `Cache_Enabler_Disk::_file_path()` issue that was introduced in version 1.4.0 when I changed the `Cache_Enabler_Disk::_file_path()` to use `get_site_url()` (PR #96). This caused the WordPress default domain redirect to not occur if the cached page already existed (e.g. `https://example.com` would not redirect to `https://www.example.com` after `https://www.example.com` was cached). This occurred because `Cache_Enabler_Disk::_file_path()` was able to find the cached page through `get_site_url()` and then deliver it (by PHP). Instead, `get_site_url()` should only be used when a `$path` parameter is provided, like when clearing the cache by URL.

Add cache bypass method for the `WP_CACHE` constant. By default WordPress core will define `WP_CACHE` as `false` (in the `wp-includes/default-constants.php` file), so checking `defined( 'WP_CACHE' )` will always return `true` (meaning all `! defined( 'WP_CACHE' )` checks are unnecessary and have been removed). Cache will now be bypassed if `define('WP_CACHE', false);` is set, either by the WordPress core or in the `wp-config.php` file. This allows Cache Enabler to honor the `WP_CACHE` constant and is also helpful in the event caching needs to be disabled in certain environments (e.g. development).

Fix advanced cache settings issue that occurred in version 1.4.0 by adding a temporary clean in `Cache_Enabler::on_ce_update()` to delete incorrect file(s).

Add nonce names back that were removed in PR #96. Keep the names for now (instead of the default) but use better naming convention in the future.

Add translation descriptions for translators to improve the internationalization process and help expand the localization.