### PR TITLE
fix cache clearing

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1353,7 +1353,6 @@ final class Cache_Enabler {
                 self::clear_home_page_cache();
             // subsite
             } else {
-                $clear_url .= $blog_path;
                 // clear subsite cache
                 self::clear_page_cache_by_url( $clear_url );
             }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.4.6 =
+* Fix cache clearing for subdirectory multisite networks (#103)
+
 = 1.4.5 =
 * Update WP_CACHE constant handling (#102)
 * Add cache bypass method for WP_CACHE constant (#102)


### PR DESCRIPTION
Fix cache clearing issue for subdirectory multisite networks that was introduced in version 1.4.0 when I added `Cache_Enabler::clear_blog_id_cache()` (PR #96). This caused only the main site in a subdirectory multisite network to be cleared properly when using the "Clear Cache" admin bar button. This occurred because the blog path was duplicated in `$clear_url`.