### PR TITLE
fix HTTPS scheme prefix detection for nginx/php-fpm servers

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -3,7 +3,7 @@
  * Cache Enabler advanced cache
  *
  * @since   1.2.0
- * @change  1.4.2
+ * @change  1.4.7
  */
 
 // check if request method is GET
@@ -15,7 +15,7 @@ if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || $_SERVER['REQUEST_METHOD'] !== 'GE
 $path = _ce_file_path();
 
 // scheme
-$scheme = ( ( isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTPS'] ) ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
+$scheme = ( ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
 
 // path to cached variants
 $path_html      = $path . $scheme . '-index.html';

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -460,14 +460,14 @@ final class Cache_Enabler_Disk {
      * get file scheme
      *
      * @since   1.4.0
-     * @change  1.4.2
+     * @change  1.4.7
      *
      * @return  string  https or http
      */
 
     private static function _file_scheme() {
 
-        return ( ( isset( $_SERVER['HTTPS'] ) && ! empty( $_SERVER['HTTPS'] ) ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
+        return ( ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
     }
 
 


### PR DESCRIPTION
On nginx/php-fpm systems the check for HTTPS might report incorrectly
as $_SERVER['HTTPS'] isn't empty on nginx/php-fpm but maybe set to a
value of = off as per #108. This fixes the 2 instances of the check
with a check for $_SERVER['HTTPS'] !== 'off' which would still apply on
Apache systems' PHP if empty