### PR TITLE
add clear types for strict cache clearing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -83,7 +83,10 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.4.7 =
 * Update getting wp-config.php if one level above installation (#106)
-* Fix advanced cache settings recognition for main site in subdirectory network
+* Add clear types for strict cache clearing (#110)
+* Fix advanced cache settings recognition for subdirectory multisite networks
+* Fix WP-CLI clear command for post IDs (#110)
+* Fix scheme-based caching for NGINX/PHP-FPM (#109)
 * Fix trailing slash handling
 
 = 1.4.6 =


### PR DESCRIPTION
Add clear types to `Cache_Enabler::clear_page_cache_by_url()` to either clear the `page` or entire `dir`. This change updates `Cache_Enabler_Disk::delete_asset()` to unlink all files in that directory. If that directory is empty afterwards delete it. Previously the entire directory was cleared, which means any subdirectories (e.g. subpages) beneath it would also be cleared. While this behavior is required in some cases it should not be the default. This change means checking for the home page URL in `Cache_Enabler::clear_page_cache_by_url()` is no longer required. This is quite helpful in other cases too. For example, when a subsite in a subdirectory network clears the home page cache, whether from the admin bar "Clear URL Cache" button or the WP-CLI `clear` command, only the home page cache is cleared and not that entire subsite. This change brings the cache clearing behavior to perform as you would expect.

Update `Cache_Enabler::clear_page_cache_by_url()`:

* Check if the URL is empty instead of `Cache_Enabler_Disk::delete_asset()`. There is no need to kill the execution. This change will prevent the `ce_action_cache_by_url_cleared` action hook from firing if the URL is empty.

* Add `$clear_url` argument to `ce_action_cache_by_url_cleared` action hook to pass the full or relative URL that was cleared. This is helpful if you want to use that URL to purge other caches (e.g. content delivery network).

Update `Cache_Enabler_Disk::_clear_dir()` to delete an empty directory and then check the parent directory. If it is also empty delete it. Keep checking the directory one level above until the directory is not empty. This will be used to ensure empty directories are deleted (like if `2020/08/*index*` existed but `2020` was empty).

Add `Cache_Enabler_Disk::_get_dir()` to scan and get the directory data because this information is required in multiple places. It will also be required with fixing the reported cache size and adding a new safety Cache Behavior setting before rolling out the ability to cache more unique pages (e.g. search results).

Delete `Cache_Enabler_Disk::clear_home()` because this is no longer required when the home page can now be cleared by using `Cache_Enabler::clear_page_cache_by_url()`. I have left the `ce_action_home_page_cache_cleared` action hook for now until we reevaluate all of the Cache Enabler hooks.

Fix clearing by post ID issue in WP-CLI command that was introduced in version 1.4.0 when I changed the parameter type validation to use `is_int()` (PR #96). This occurred because all post IDs sent from `Cache_Enabler_CLI::clear()` were strings and would not validate as integers. Turns out `! $post_id = (int) $post_id` was converting a string to an integer (type casting would return false if it could not be changed). Update the `$post_id` and `$blog_id` parameter types in `Cache_Enabler::clear_page_cache_by_post_id()` and `Cache_Enabler::clear_blog_id_cache()` to also be acceptable as a string and use this same logic, however, first validate if it is not an integer before trying to convert it. This was done instead of sending all post IDs as integers from `Cache_Enabler_CLI::clear()` because this way does not require an additional loop to save the IDs as integers. On a side note, updating `Cache_Enabler_Disk::_file_path()` to use `get_site_url()` in PR #96 (updated this to only be done when a `$path` parameter is provided in PR #102) did fix an undefined index error that occurred in version 1.3.5 when using the WP-CLI `clear` command for Cache Enabler.