### PR TITLE
update WP-CLI clear subcommand

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -87,6 +87,4 @@ function cache_autoload( $class ) {
 // load the WP-CLI command
 if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
     require_once CE_DIR . '/inc/cache_enabler_cli.class.php';
-
-    WP_CLI::add_command( 'cache-enabler', 'Cache_Enabler_CLI' );
 }

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1224,17 +1224,12 @@ final class Cache_Enabler {
      * clear page cache by post ID
      *
      * @since   1.0.0
-     * @change  1.4.7
+     * @change  1.4.8
      *
      * @param   integer|string  $post_id  post ID
      */
 
     public static function clear_page_cache_by_post_id( $post_id ) {
-
-        // check if post ID is empty
-        if ( empty( $post_id ) ) {
-            return;
-        }
 
         // validate integer
         if ( ! is_int( $post_id ) ) {
@@ -1255,21 +1250,21 @@ final class Cache_Enabler {
      * clear page cache by URL
      *
      * @since   1.0.0
-     * @change  1.4.7
+     * @change  1.4.8
      *
-     * @param   string  $clear_url   full or relative URL of a page
-     * @param   string  $clear_type  clear all specific `page` variants or the entire `dir`
+     * @param   string  $clear_url   full URL of a cached page
+     * @param   string  $clear_type  clear all specific cached `page` variants or the entire `dir`
      */
 
     public static function clear_page_cache_by_url( $clear_url, $clear_type = 'page' ) {
 
-        // check if clear URL is empty
-        if ( empty( $clear_url ) ) {
+        // validate string
+        if ( ! is_string( $clear_url ) ) {
             return;
         }
 
-        // validate string
-        if ( ! is_string( $clear_url ) ) {
+        // validate URL
+        if ( ! filter_var( $clear_url, FILTER_VALIDATE_URL ) ) {
             return;
         }
 
@@ -1285,13 +1280,21 @@ final class Cache_Enabler {
      * clear home page cache
      *
      * @since   1.0.7
-     * @change  1.4.7
+     * @change  1.4.8
+     *
+     * @param   integer  $blog_id  blog ID
      */
 
-    public static function clear_home_page_cache() {
+    public static function clear_home_page_cache( $blog_id = null ) {
+
+        // set blog ID if given, get current site otherwise
+        $blog_id = ( $blog_id ) ? $blog_id : get_current_blog_id();
+
+        // get home page URL
+        $home_page_url = get_site_url( $blog_id );
 
         // clear home page cache
-        self::clear_page_cache_by_url( get_site_url() );
+        self::clear_page_cache_by_url( $home_page_url );
 
         // clear home page cache post hook
         do_action( 'ce_action_home_page_cache_cleared' );
@@ -1302,7 +1305,7 @@ final class Cache_Enabler {
      * clear blog ID cache
      *
      * @since   1.4.0
-     * @change  1.4.7
+     * @change  1.4.8
      *
      * @param   integer|string  $blog_id  blog ID
      */
@@ -1324,6 +1327,11 @@ final class Cache_Enabler {
             }
         }
 
+        // check if blog ID exists
+        if ( ! in_array( $blog_id, self::_get_blog_ids() ) ) {
+            return;
+        }
+
         // set clear URL
         $clear_url = get_site_url( $blog_id );
 
@@ -1340,10 +1348,8 @@ final class Cache_Enabler {
             if ( $blog_path === '/' ) {
                 // get blog paths
                 $blog_paths = self::_get_blog_paths();
-
                 // get blog domain
                 $blog_domain = self::get_blog_domain();
-
                 // glob path
                 $glob_path = CE_CACHE_DIR . '/' . $blog_domain;
 
@@ -1359,7 +1365,7 @@ final class Cache_Enabler {
                 }
 
                 // clear home page cache
-                self::clear_home_page_cache();
+                self::clear_home_page_cache( $blog_id );
             // subsite
             } else {
                 // clear subsite cache

--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -6,7 +6,7 @@ defined( 'ABSPATH' ) || exit;
 
 
 /**
- * Interact with Cache Enabler
+ * Interact with Cache Enabler.
  *
  * @since  1.3.5
  */
@@ -25,16 +25,26 @@ class Cache_Enabler_CLI {
      * [--urls=<url>]
      * : Clear the cache for the given URL(s). Separate multiple URLs with commas.
      *
+     * [--sites=<site>]
+     * : Clear the cache for the given blog ID(s). Separate multiple blog IDs with commas.
+     *
      * ## EXAMPLES
      *
-     * # Clear all page caches
-     * wp cache-enabler clear
+     *    # Clear all pages cache.
+     *    $ wp cache-enabler clear
+     *    Success: Cache cleared.
      *
-     * # Clear the cache for object IDs 1, 2, and 3
-     * wp cache-enabler clear --ids=1,2,3
+     *    # Clear the page cache for post IDs 1, 2, and 3.
+     *    $ wp cache-enabler clear --ids=1,2,3
+     *    Success: Pages cache cleared.
      *
-     * # Clear the cache for a particular URL
-     * wp cache-enabler clear --urls=https://example.com/about-us
+     *    # Clear the page cache for a particular URL.
+     *    $ wp cache-enabler clear --urls=https://example.com/about-us
+     *    Success: Page cache cleared.
+     *
+     *    # Clear all pages cache for sites with blog IDs 1, 2, and 3.
+     *    $ wp cache-enabler clear --sites=1,2,3
+     *    Success: Sites cache cleared.
      *
      * @alias clear
      */
@@ -44,22 +54,49 @@ class Cache_Enabler_CLI {
         $assoc_args = wp_parse_args(
             $assoc_args,
             array(
-                'ids'  => '',
-                'urls' => '',
+                'ids'   => '',
+                'urls'  => '',
+                'sites' => '',
             )
         );
 
-        // clear everything if we are not given IDs and/or URLs
-        if ( empty( $assoc_args['ids'] ) && empty( $assoc_args['urls'] ) ) {
+        // clear complete cache if no associative arguments are given
+        if ( empty( $assoc_args['ids'] ) && empty( $assoc_args['urls'] ) && empty( $assoc_args['sites'] ) ) {
             Cache_Enabler::clear_total_cache();
 
-            return WP_CLI::success( esc_html__( 'The page cache has been cleared.', 'cache-enabler' ) );
+            return WP_CLI::success( ( is_multisite() && is_plugin_active_for_network( CE_BASE ) ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Cache cleared.', 'cache-enabler' ) );
         }
 
-        // clear specific IDs and/or URLs
-        array_map( 'Cache_Enabler::clear_page_cache_by_post_id', explode( ',', $assoc_args['ids'] ) );
-        array_map( 'Cache_Enabler::clear_page_cache_by_url', explode( ',', $assoc_args['urls'] ) );
+        // clear page(s) cache by post ID(s) and/or URL(s)
+        if ( ! empty( $assoc_args['ids'] ) || ! empty( $assoc_args['urls'] ) ) {
+            array_map( 'Cache_Enabler::clear_page_cache_by_post_id', explode( ',', $assoc_args['ids'] ) );
+            array_map( 'Cache_Enabler::clear_page_cache_by_url', explode( ',', $assoc_args['urls'] ) );
 
-        WP_CLI::success( 'The requested caches have been cleared.', 'cache-enabler' );
+            // check if there is more than one ID and/or URL
+            $separators = substr_count( $assoc_args['ids'], ',' ) + substr_count( $assoc_args['urls'], ',' );
+
+            if ( $separators > 0 ) {
+                return WP_CLI::success( esc_html__( 'Pages cache cleared.', 'cache-enabler' ) );
+            } else {
+                return WP_CLI::success( esc_html__( 'Page cache cleared.', 'cache-enabler' ) );
+            }
+        }
+
+        // clear pages cache by blog ID(s)
+        if ( ! empty( $assoc_args['sites'] ) ) {
+            array_map( 'Cache_Enabler::clear_blog_id_cache', explode( ',', $assoc_args['sites'] ) );
+
+            // check if there is more than one site
+            $separators = substr_count( $assoc_args['sites'], ',' );
+
+            if ( $separators > 0 ) {
+                return WP_CLI::success( esc_html__( 'Sites cache cleared.', 'cache-enabler' ) );
+            } else {
+                return WP_CLI::success( esc_html__( 'Site cache cleared.', 'cache-enabler' ) );
+            }
+        }
     }
 }
+
+// add WP-CLI command for Cache Enabler
+WP_CLI::add_command( 'cache-enabler', 'Cache_Enabler_CLI' );

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -418,33 +418,34 @@ final class Cache_Enabler_Disk {
      * get cached file path
      *
      * @since   1.0.0
-     * @change  1.4.7
+     * @change  1.4.8
      *
-     * @param   string  $path  URI or permalink
-     * @return  string  $diff  path to cached file
+     * @param   string  $url  full URL of a cached page
+     * @return  string        path to cached file
      */
 
-    private static function _file_path( $path = null ) {
+    private static function _file_path( $url = null ) {
 
-        $path = sprintf(
+        $file_path = sprintf(
             '%s%s%s%s',
             CE_CACHE_DIR,
             DIRECTORY_SEPARATOR,
             parse_url(
-                ( $path ) ? get_site_url() : 'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
+                ( $url ) ? $url : 'http://' . strtolower( $_SERVER['HTTP_HOST'] ),
                 PHP_URL_HOST
             ),
             parse_url(
-                ( $path ) ? $path : $_SERVER['REQUEST_URI'],
+                ( $url ) ? $url : $_SERVER['REQUEST_URI'],
                 PHP_URL_PATH
             )
         );
 
-        if ( is_file( $path ) ) {
-            wp_die( 'Path is not valid.' );
+        if ( is_file( $file_path ) ) {
+            header( $_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found', true, 404 );
+            exit;
         }
 
-        return trailingslashit( $path );
+        return trailingslashit( $file_path );
     }
 
 
@@ -527,7 +528,7 @@ final class Cache_Enabler_Disk {
      * get settings file
      *
      * @since   1.4.0
-     * @change  1.4.0
+     * @change  1.4.8
      *
      * @return  string  settings file path
      */
@@ -537,14 +538,14 @@ final class Cache_Enabler_Disk {
         // network with subdirectory configuration
         if ( is_multisite() && ! is_subdomain_install() ) {
             // get blog path
-            $path = trim( get_blog_details()->path, '/' );
+            $blog_path = trim( get_blog_details()->path, '/' );
             // check if subsite
-            if ( ! empty( $path ) ) {
-                $path = '-' . $path;
+            if ( ! empty( $blog_path ) ) {
+                $blog_path = '-' . $blog_path;
             }
         // single site, network subdirectory main site, or any network subdomain site
         } else {
-            $path = '';
+            $blog_path = '';
         }
 
         // get settings file
@@ -552,7 +553,7 @@ final class Cache_Enabler_Disk {
             '%s-%s%s.json',
             WP_CONTENT_DIR . '/plugins/cache-enabler/settings/cache-enabler-advcache',
             Cache_Enabler::get_blog_domain(),
-            $path
+            $blog_path
         );
 
         return $settings_file;

--- a/readme.txt
+++ b/readme.txt
@@ -47,14 +47,17 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = WP-CLI =
 
-* Clear all page caches
-  `wp cache-enabler clear`
+* Clear all pages cache.
+    `wp cache-enabler clear`
 
-* Clear the cache for object IDs 1, 2, and 3
-  `wp cache-enabler clear --ids=1,2,3`
+* Clear the page cache for post IDs 1, 2, and 3.
+    `wp cache-enabler clear --ids=1,2,3`
 
-* Clear the cache for a particular URL
-  `wp cache-enabler clear --urls=https://example.com/about-us`
+* Clear the page cache for a particular URL.
+    `wp cache-enabler clear --urls=https://example.com/about-us`
+
+* Clear all pages cache for sites with blog IDs 1, 2, and 3.
+    `wp cache-enabler clear --sites=1,2,3`
 
 
 = Website =
@@ -81,11 +84,15 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.4.8 =
+* Update WP-CLI clear subcommand messages (#111)
+* Update WP-CLI clear subcommand for multisite networks (#111)
+
 = 1.4.7 =
 * Update getting wp-config.php if one level above installation (#106)
 * Add clear types for strict cache clearing (#110)
 * Fix advanced cache settings recognition for subdirectory multisite networks
-* Fix WP-CLI clear command for post IDs (#110)
+* Fix WP-CLI clear subcommand for post IDs (#110)
 * Fix scheme-based caching for NGINX/PHP-FPM (#109)
 * Fix trailing slash handling
 


### PR DESCRIPTION
Update WP-CLI `clear` subcommand:

* Add `[--sites=<site>]` as an associative argument to allow the site cache in a multisite network to be cleared.

* Update success messages to better describe what was performed. Not using the `_n()` function for plurals because one comma separator means there are two pages or sites to be cleared. Currently success messages will always be returned, even if there was not a cache that was actually cleared.

Update `Cache_Enabler::clear_page_cache_by_post_id()` to not check if `$post_id` is empty because this will be done when validating the parameter as an integer.

Update `Cache_Enabler::clear_page_cache_by_url()`:

* Validate the URL now that a full URL is required (due to the `Cache_Enabler_Disk::_file_path()` updates below). Simple check to ensure the URL at least has a scheme and host.

* Do not check if `$clear_url` is empty because this will be done when validating the parameter as a string and/or URL.

Update `Cache_Enabler::clear_home_page_cache()` to have an optional `$blog_id` parameter. This will allow the correct home page URL to be cleared when clearing a site cache in a subdirectory multisite network with WP-CLI. No parameter validation was added because this is currently handled beforehand.

Update `Cache_Enabler::clear_blog_id_cache()`:

* Check if the blog ID exists to avoid database errors when attempting to clear the site cache for a site that does not exist in a multisite network with WP-CLI.

* Pass `$blog_id` to `self::clear_home_page_cache()` to ensure the correct home page cache is cleared when clearing a site cache in a subdirectory multisite network with WP-CLI.

Update `Cache_Enabler_Disk::_file_path()`:

* Update the parameter to be `$url` instead of `$path` because when this parameter is provided it will be a URL. Currently this parameter is only passed when clearing a page cache by URL, however, `$url` was chosen instead of `$clear_url` as other cases beyond clearing the cache may arise in the future when needing the server file path through a provided URL.

* Update the `$path` variable name to `$file_path` instead as we move to more specific variable naming. Update this variable to use the passed `$url` parameter value instead of `get_site_url()` when getting the host. This is required to ensure the correct file path is returned when clearing a URL in a multisite network with WP-CLI. This actually makes more sense as we are already setting the correct URL when sending it to be cleared. No reason to generate the host in the file path again when getting the file path to clear. This change means the provided URL will need to be full and not relative. As far as I know this would only affect the WP-CLI `clear` subcommand if a relative URL was provided (e.g. `wp cache-enabler clear --urls=/about-us`). This functionality is not documented so I am unsure if it is being used out in the wild. If it turns out that it is we can add support for clearing relative URLs with WP-CLI by getting the current site URL and appending the relative URL if the URL validation fails. This would only work for single installations, subdirectory multisite networks, and the main site in a subdomain multisite network (unless a blog ID variable was passed for subsites in a subdomain multisite network, which I would not want to add as the full URL should just be used in that case).

* Update the `is_file()` check to return a `404` error if the path is in fact a file and not a directory (as we do in `advanced-cache.php`).

Update `Cache_Enabler_Disk::_get_settings()` variables to be `$blog_path` instead of `$path` as we move to more specific variable naming.