### PR TITLE
update WebP URL conversion

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.4.8 =
+* Update WebP URL conversion (#116)
 * Update WP-CLI clear subcommand messages (#111)
 * Update WP-CLI clear subcommand for multisite networks (#111)
 * Fix cache clearing for installations in a subdirectory


### PR DESCRIPTION
Remove both `Cache_Enabler_Disk::_convert_webp_src()` and `Cache_Enabler_Disk::_convert_webp_srcset()` and instead update `Cache_Enabler_Disk::_convert_webp()` to handle converting the image path(s) to WebP. This simplifies the logic and still allows one (e.g. `src`) or more (e.g. `srcset`) image URLs to be replaced. Explode by `','` instead of `', '` and then trim spaces to avoid edge cases (#115). When imploding the proper formatting will be applied. This change allows images in any directory to be replaced instead of images only in the uploads directory (default `wp-content/uploads` or custom). The `.webp` extension is now first appended and then the default extension is removed because it makes the conversion more simple by requiring less logic.

Update WebP regular expression matching:

* Previously any attribute that contained `src`, `set`, and `ref` and ended in `.jpg`, `.jpeg`, or `.png` would match (case sensitive). Instead, any `src`, `srcset`, and `data-*` attribute with a value ending in `.jpg`, `.jpeg`, or `.png` will match (case insensitive). This change will cover the wide array of HTML attributes that are used for lazy loading. This will change the default behavior to no longer rewrite the `href` attribute. I do not believe this should be the default behavior because we are replacing image sources not links, but should be able to be customized with a filter hook.

* Previously if an image had a query string a match would be made. Instead, only images without query strings will match. This will avoid potentially breaking other functionality (e.g. URL query parameters for an image processing engine and/or service). 

* Update pattern to also match an image invoked with inline CSS (#48).

When reviewing all hooks for version 1.5.0 we may want to create new filter hooks for the changes above, for example:

* Attribute filter hooks to allow the HTML attributes to be customized, like adding `href` and only defining specific `data-*` attributes to be matched.

* Query string filter hook to enable matching images with query strings.

* CSS function filter hook to disable rewriting inline CSS.

Regex tests (until unit tests are written):

* Old pattern: https://regex101.com/r/3PEH03

* New pattern: https://regex101.com/r/flaGLY

Closes #48
Fixes #51 and fixes #115