### PR TITLE
update and fix WebP URL conversion

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,10 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.5.0 =
+* Update WebP URL conversion for images with density descriptors (#125)
+* Fix WebP URL conversion for installations in a subdirectory (#125)
+
 = 1.4.9 =
 * Fix WebP URL conversion
 


### PR DESCRIPTION
Update `Cache_Enabler_Disk::_create_files()`:

* Rename `$regex_rule` variable to `$image_urls_regex` to make it more clear what it is matching.

* Update regular expression pattern to produce a match if density descriptors are used (e.g. `/wp-content/uploads/example.jpg 1x, /wp-content/uploads/example@2x.jpg 2x`). The change made was `w` to `[wx]`.

    * Regex tests (until unit tests are written):

        * Old pattern: https://regex101.com/r/RKepNP

        * New pattern: https://regex101.com/r/JwG53y

Update `Cache_Enabler_Disk::_convert_webp()` to start the conversion as soon as one image is found instead of counting them.

Fix `Cache_Enabler_Disk::_image_path()` to return correct image path if installation is in a subdirectory. This issue was introduced in version 1.4.8 when allowing images in any directory to be replaced instead of images only in the uploads directory (PR #116). Previously the subdirectory name was being duplicated (from the `ABSPATH` and the received `$image_url`). The leading slash in the `$image_url_path` variable will always be trimmed in case a relative URL is provided without a leading slash. The first directory is then taken as the potential installation directory (e.g. `wordpress/`). If the first directory is in the `ABSPATH` it is removed from the `ABSPATH` (e.g. `/path/to/public/wordpress/` would become `/path/to/public/`). The `$image_path` is then created by concatenating the potentially updated `ABSPATH` and `$image_url_path` (e.g. `/path/to/public/wordpress/wp-content/uploads/example.jpg`).