### PR TITLE
fix cache clearing for subdirectory installations

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -859,7 +859,7 @@ final class Cache_Enabler {
      * process clear request
      *
      * @since   1.0.0
-     * @change  1.4.6
+     * @change  1.5.0
      *
      * @param   array  $data  array of metadata
      */
@@ -894,8 +894,9 @@ final class Cache_Enabler {
         // set clear ID cookie
         setcookie( 'cache_enabler_clear_id', $_GET['_cid'] );
 
-        // set clear URL without query string
-        $clear_url = preg_replace( '/\?.*/', '', home_url( add_query_arg( null, null ) ) );
+        // set clear URL without query string and check if installation is in a subdirectory
+        $installation_dir = parse_url( get_home_url(), PHP_URL_PATH );
+        $clear_url = str_replace( $installation_dir, '', get_home_url() ) . preg_replace( '/\?.*/', '', $_SERVER['REQUEST_URI'] );
 
         // network activated
         if ( is_multisite() && is_plugin_active_for_network( CE_BASE ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.5.0 =
 * Update WebP URL conversion for images with density descriptors (#125)
+* Fix cache clearing for installations in a subdirectory (#127)
 * Fix WebP URL conversion for installations in a subdirectory (#125)
 
 = 1.4.9 =


### PR DESCRIPTION
Fix `Cache_Enabler::process_clear_request()` to set the correct `$clear_url` for installations in a subdirectory when the Clear URL Cache admin bar button is used. Previously the subdirectory name was being duplicated. This has been the current behavior since version 1.1.0 when this feature was first introduced (d91a78b). The `get_home_url()` value returned is checked for a URL path. If a URL path exists, indicating a subdirectory is used, then it is removed before concatenating it with the received `$_SERVER['REQUEST_URI']`.

Fixes #126