### PR TITLE
Add check for existence of file before calling filesize()

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -405,7 +405,7 @@ final class Cache_Enabler_Disk {
             // check if directory
             if ( is_dir( $object ) ) {
                 $size += self::cache_size( $object );
-            } else {
+            } else if ( file_exists( $object ) ) {
                 $size += filesize( $object );
             }
         }


### PR DESCRIPTION
As per #133, Cache Enabler was throwing lots of warnings in the server error log every time the cache was being cleared.

This was nailed down to the filesize() function that was being called before checking if the file existed.

This code modification adds a check for the existence of the file before calling the filesize() function.