### PR TITLE
update output buffering timing to start earlier

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -6,7 +6,7 @@
  * @change  1.5.0
  */
 
-// check if request method is GET
+// check request method
 if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || $_SERVER['REQUEST_METHOD'] !== 'GET' ) {
     return false;
 }
@@ -42,13 +42,13 @@ $settings = _read_settings( $settings_file );
 
 // check trailing slash
 if ( isset( $settings['permalink_structure_has_trailing_slash'] ) && $settings['permalink_structure_has_trailing_slash'] ) {
-    // if trailing slash is set and missing
-    if ( ! preg_match( '/\/(|\?.*)$/', $_SERVER['REQUEST_URI'] ) ) {
+    // if trailing slash is set and missing (ignoring root index and file extensions)
+    if ( preg_match( '/\/[^\.\/\?]+(\?.*)?$/', $_SERVER['REQUEST_URI'] ) ) {
         return false;
     }
 } elseif ( isset( $settings['permalink_structure_has_trailing_slash'] ) && ! $settings['permalink_structure_has_trailing_slash'] ) {
-    // if trailing slash is not set and appended
-    if ( preg_match( '/(?!^)\/(|\?.*)$/', $_SERVER['REQUEST_URI'] ) ) {
+    // if trailing slash is not set and appended (ignoring root index and file extensions)
+    if ( preg_match( '/\/[^\.\/\?]+\/(\?.*)?$/', $_SERVER['REQUEST_URI'] ) ) {
         return false;
     }
 }
@@ -90,7 +90,7 @@ if ( ! empty( $_COOKIE ) ) {
 }
 
 // set X-Cache-Handler response header
-header( 'X-Cache-Handler: wp' );
+header( 'X-Cache-Handler: WP' );
 
 // get request headers
 if ( function_exists( 'apache_request_headers' ) ) {

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -175,7 +175,7 @@ final class Cache_Enabler_Disk {
     public static function get_asset() {
 
         // set X-Cache-Handler response header
-        header( 'X-Cache-Handler: php' );
+        header( 'X-Cache-Handler: PHP' );
 
         // get request headers
         if ( function_exists( 'apache_request_headers' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.5.0 =
+* Update output buffer timing to start earlier on the `init` hook instead of `template_redirect` (#137)
 * Update default cache behavior to not bypass the cache for query strings (#129)
 * Update cache clearing setting for when any post type is published to clear the associated cache by default (#129)
 * Update settings page layout (#129)
@@ -113,7 +114,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 * Fix file permissions requirement notice
 
 = 1.4.7 =
-* Update getting wp-config.php if one level above installation (#106)
+* Update getting `wp-config.php` if one level above installation (#106)
 * Add clear types for strict cache clearing (#110)
 * Fix advanced cache settings recognition for subdirectory multisite networks
 * Fix WP-CLI clear subcommand for post IDs (#110)
@@ -125,8 +126,8 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 * Fix cache clearing for subdirectory multisite networks (#103)
 
 = 1.4.5 =
-* Update WP_CACHE constant handling (#102)
-* Add cache bypass method for WP_CACHE constant (#102)
+* Update `WP_CACHE` constant handling (#102)
+* Add cache bypass method for `WP_CACHE` constant (#102)
 * Add translation descriptions (#102)
 * Fix cache handling for default redirects (#102)
 


### PR DESCRIPTION
Updated output buffering to start earlier on the `init` hook instead of `template_redirect`. This was done to increase the compatibility with third parties (#78 and #120). Previously anything that added data to the HTML output before `template_redirect` was not being captured in our buffer. This means in some cases cached pages were incomplete and missing data. The output buffer does not start unless the template used is the directory index. (This is currently set to `index.php` but a filter will be added in case the directory index has been renamed and set in the server configuration file.) This will improve performance by not starting an output buffer when not needed. All other checks still need to be done in `Cache_Enabler::_bypass_cache()` because that data being checked is not available at `init` yet. If a page is expired the stale cached page will now be delivered (through PHP handling) while the cached page is being updated. Changing the output buffering timing in this way will allow PHP to automatically close the output buffer started by Cache Enabler instead of trying to clean our specific output buffer at a different hook fired later (because we would not be certain if the output buffer being cleaned is the one we started).

Updated regular expressions used for checking whether or not the trailing slash exists. This was updated to ensure file extensions that could potentially be cached (e.g. `.xml`) are also ignored (as briefly explained in 626aa59). This will make checking for trailing slashes more strict and prevent potential unwanted cache bypassing.

Added `Cache_Enabler::_is_cacheable()` to check whether or not the content of a page should even be cached. This will ensure invalid page content is not processed. This means `Cache_Enabler::_is_sitemap()` is no longer required and has been removed. Furthermore, checking if the output buffer is empty is not required when a page is only cacheable if it has the required HTML tags. This method was inspired by Autoptimize and is credited to @futtta (thank you).

Closes #78 and closes #120