### PR TITLE
update clear request processing

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -31,21 +31,6 @@ final class Cache_Enabler_Disk {
 
 
     /**
-     * permalink check
-     *
-     * @since   1.0.0
-     * @change  1.0.0
-     *
-     * @return  boolean  true if installed
-     */
-
-    public static function is_permalink() {
-
-        return get_option( 'permalink_structure' );
-    }
-
-
-    /**
      * store asset
      *
      * @since   1.0.0

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,8 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.5.0 =
+* Update cache cleared admin notice (#139)
+* Update admin bar clear cache buttons (#139)
 * Update output buffer timing to start earlier on the `init` hook instead of `template_redirect` (#137)
 * Update default cache behavior to not bypass the cache for query strings (#129)
 * Update cache clearing setting for when any post type is published to clear the associated cache by default (#129)
@@ -106,8 +108,8 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.4.8 =
 * Update WebP URL conversion for inline CSS (#116)
-* Update WP-CLI clear subcommand messages (#111)
-* Update WP-CLI clear subcommand for multisite networks (#111)
+* Update WP-CLI `clear` subcommand messages (#111)
+* Update WP-CLI `clear` subcommand for multisite networks (#111)
 * Fix WebP URL conversion image matching edge cases (#116)
 * Fix cache clearing for installations in a subdirectory
 * Fix advanced cache settings recognition for installations in a subdirectory
@@ -117,8 +119,8 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 * Update getting `wp-config.php` if one level above installation (#106)
 * Add clear types for strict cache clearing (#110)
 * Fix advanced cache settings recognition for subdirectory multisite networks
-* Fix WP-CLI clear subcommand for post IDs (#110)
-* Fix scheme-based caching for NGINX/PHP-FPM (#109)
+* Fix WP-CLI `clear` subcommand for post IDs (#110)
+* Fix scheme-based caching for NGINX/PHP-FPM (#109 @centminmod)
 * Fix trailing slash handling
 
 = 1.4.6 =


### PR DESCRIPTION
Update clear request processing:

* Redirect to same page even when in an admin interface. This will prevent the clear request query string from staying in the browser address bar for a cleaner way of clearing the cache. This means the clear ID is no longer required and has been removed.

* Display notice in admin interface page by checking for the `_cache_enabler_cache_cleared_<uid>` transient and then deleting it after the notice has been shown. This was done instead of adding a query parameter, like `_cache-cleared`, and then removing it after the page has loaded by including it in the `removable_query_args` filter (to then be removed by `wp_admin_canonical_url()`). This was done because it allows the notice to be displayed in any case needed, like after the cache has been cleared when saving the Cache Enabler settings. Furthermore, this behavior was not copied from how WordPress displays certain admin notices because first the redirect occurs and then the query parameter is removed, whereas this way it just redirects to the same page.

* Update notice messages to "Cache cleared." and "Network cache cleared." instead of "The cache has been cleared.".

Update notices being called with `admin_notices` to not use the `show_message()` function as this is unnecessary when printing admin notices from this hook.

Combine `Cache_Enabler::warning_is_permalink()` with `Cache_Enabler::requirements_check()` as it is also a requirement of Cache Enabler.

Add `Cache_Enabler::_is_plain_permalink_structure()` in place of `Cache_Enabler_Disk::is_permalink()`. Bypass the cache if a plain permalink structure is set instead of only creating an instance of `Cache_Enabler_Disk` if a custom permalink structure is set.