### PR TITLE
update WP_CACHE constant handling

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.5.0 =
+* Update `WP_CACHE` constant handling (#140)
 * Update cache cleared admin notice (#139)
 * Update admin bar clear cache buttons (#139)
 * Update output buffer timing to start earlier on the `init` hook instead of `template_redirect` (#137)
@@ -96,6 +97,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 * Add post type, taxonomies, author, and date archives to the new associated cache (#129)
 * Add new cache clearing setting for when any published post type is updated (#129)
 * Add new cache exclusions setting for query strings (#129)
+* Fix `WP_CACHE` constant not being set edge case (#140)
 * Fix advanced cache settings from using unvalidated data (#129)
 * Fix clear URL admin bar button for installations in a subdirectory (#127)
 * Fix WebP URL conversion for installations in a subdirectory (#125)


### PR DESCRIPTION
Update how Cache Enabler sets and unsets the `WP_CACHE` constant in the `wp-config.php` file:

* Update getting `wp-config.php` contents as a string instead of an array. This simplifies the logic by allowing simple searches to find and replace what we need.

* Update it to be more strict by only setting the `WP_CACHE` constant if we believe it is the default `wp-config.php`, which is currently true if we find `/** Sets up WordPress vars and included files. */`. This makes it so changes are not being made to a heavily customized config file, like if using Bedrock (#136).

* Update what is inserted from `define( 'WP_CACHE', true ); // Added by Cache Enabler` to the following instead:

    ```
    /** Enables page caching for Cache Enabler. */
    if ( ! defined( 'WP_CACHE' ) ) {
        define( 'WP_CACHE', true );
    } 
    ```

    This will prevent potential constant already defined errors if `WP_CACHE` is defined elsewhere and we end up setting the constant (@nlemoine).

* Update the location where the Cache Enabler config lines are inserted. Previously, the old single line was inserted at the very top beneath the opening PHP tag. Now, insert new config lines to be above the minimum requirement, which is before WordPress sets up its vars and included files. If it is set below this the default WordPress constant would be applied that is set in the `wp-includes/default-constants.php` file. This cleans up how we change the config file.

* Update how the `Cache_Enabler::_set_wp_cache_constant()` method is called. No longer check the `WP_CACHE` constant itself beforehand because the checks done in this method are enough. This fixes the issue occurring in #65 where the `WP_CACHE` constant would not be added if Cache Enabler was activated immediately after being deactivated.

Closes #65 and closes #136