### PR TITLE
update scheme-based caching port fallback

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -15,7 +15,7 @@ if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || $_SERVER['REQUEST_METHOD'] !== 'GE
 $path = _file_path();
 
 // scheme
-$scheme = ( ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
+$scheme = ( ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) || $_SERVER['SERVER_PORT'] == '443' ) ? 'https' : 'http';
 
 // path to cached variants
 $path_html      = $path . $scheme . '-index.html';

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -449,14 +449,14 @@ final class Cache_Enabler_Disk {
      * get file scheme
      *
      * @since   1.4.0
-     * @change  1.4.7
+     * @change  1.5.0
      *
      * @return  string  https or http
      */
 
     private static function _file_scheme() {
 
-        return ( ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) || $_SERVER['SERVER_PORT'] === '443' ) ? 'https' : 'http';
+        return ( ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ) || $_SERVER['SERVER_PORT'] == '443' ) ? 'https' : 'http';
     }
 
 


### PR DESCRIPTION
Update the port fallback when getting the scheme to be a loose comparison instead of strict in case the port is defined as an integer.