### PR TITLE
update code base formatting

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -10,25 +10,27 @@ Version: 1.4.9
 */
 
 /*
-Copyright (C)  2020 KeyCDN
-Copyright (C)  2015 Sergej Müller
+Copyright (C) 2020 KeyCDN
+Copyright (C) 2015 Sergej Müller
+
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
+
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-
-// exit
-defined( 'ABSPATH' ) || exit;
-
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 // constants
 define( 'CE_FILE', __FILE__ );
@@ -38,53 +40,26 @@ define( 'CE_CACHE_DIR', WP_CONTENT_DIR . '/cache/cache-enabler' );
 define( 'CE_MIN_WP', '5.1' );
 
 // hooks
-add_action(
-    'plugins_loaded',
-    array(
-        'Cache_Enabler',
-        'instance',
-    )
-);
-register_activation_hook(
-    __FILE__,
-    array(
-        'Cache_Enabler',
-        'on_activation',
-    )
-);
-register_deactivation_hook(
-    __FILE__,
-    array(
-        'Cache_Enabler',
-        'on_deactivation',
-    )
-);
-register_uninstall_hook(
-    __FILE__,
-    array(
-        'Cache_Enabler',
-        'on_uninstall',
-    )
-);
+add_action( 'plugins_loaded', array( 'Cache_Enabler', 'instance' ) );
+register_activation_hook( __FILE__, array( 'Cache_Enabler', 'on_activation' ) );
+register_deactivation_hook( __FILE__, array( 'Cache_Enabler', 'on_deactivation' ) );
+register_uninstall_hook( __FILE__, array( 'Cache_Enabler', 'on_uninstall' ) );
 
+// register autoload
+spl_autoload_register( 'cache_enabler_autoload' );
 
-// autoload register
-spl_autoload_register( 'cache_autoload' );
-
-// autoload function
-function cache_autoload( $class ) {
-    if ( in_array( $class, array( 'Cache_Enabler', 'Cache_Enabler_Disk' ) ) ) {
-        require_once(
-            sprintf(
-                '%s/inc/%s.class.php',
-                CE_DIR,
-                strtolower( $class )
-            )
+// load classes
+function cache_enabler_autoload( $class_name ) {
+    if ( in_array( $class_name, array( 'Cache_Enabler', 'Cache_Enabler_Disk' ) ) ) {
+        require_once sprintf(
+            '%s/inc/%s.class.php',
+            CE_DIR,
+            strtolower( $class_name )
         );
     }
 }
 
-// load the WP-CLI command
+// load WP-CLI command
 if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
     require_once CE_DIR . '/inc/cache_enabler_cli.class.php';
 }

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1,18 +1,15 @@
 <?php
-
-
-// exit
-defined( 'ABSPATH' ) || exit;
-
-
 /**
- * Cache_Enabler
+ * Cache Enabler base
  *
  * @since  1.0.0
  */
 
-final class Cache_Enabler {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
+final class Cache_Enabler {
 
     /**
      * plugin settings
@@ -498,7 +495,7 @@ final class Cache_Enabler {
             $wp_config_file_contents = preg_replace( '/(\/\*\* Sets up WordPress vars and included files\. \*\/)/', $ce_wp_config_lines . '$1', $wp_config_file_contents );
         }
 
-        // unset WP_CACHE constant if added by Cache Enabler
+        // unset WP_CACHE constant if set by Cache Enabler
         if ( ! $set ) {
             $wp_config_file_contents = preg_replace( '/.+Added by Cache Enabler\r\n/', '', $wp_config_file_contents ); // < 1.5.0
             $wp_config_file_contents = preg_replace( '/\/\*\* Enables page caching for Cache Enabler\. \*\/' . PHP_EOL . '.+' . PHP_EOL . '.+' . PHP_EOL . '\}' . PHP_EOL . PHP_EOL . '/', '', $wp_config_file_contents );
@@ -541,7 +538,7 @@ final class Cache_Enabler {
 
         global $wpdb;
 
-        return $wpdb->get_col("SELECT blog_id FROM `$wpdb->blogs`");
+        return $wpdb->get_col( "SELECT blog_id FROM `$wpdb->blogs`" );
     }
 
 
@@ -558,7 +555,7 @@ final class Cache_Enabler {
 
         global $wpdb;
 
-        return $wpdb->get_col("SELECT path FROM `$wpdb->blogs`");
+        return $wpdb->get_col( "SELECT path FROM `$wpdb->blogs`" );
     }
 
 
@@ -597,10 +594,7 @@ final class Cache_Enabler {
         );
 
         // merge defined settings into default settings
-        $settings = wp_parse_args(
-            $defined_settings,
-            $default_settings
-        );
+        $settings = wp_parse_args( $defined_settings, $default_settings );
 
         return $settings;
     }
@@ -705,12 +699,7 @@ final class Cache_Enabler {
             array(
                 sprintf(
                     '<a href="%s">%s</a>',
-                    add_query_arg(
-                        array(
-                            'page' => 'cache-enabler',
-                        ),
-                        admin_url( 'options-general.php' )
-                    ),
+                    admin_url( 'options-general.php?page=cache-enabler' ),
                     esc_html__( 'Settings', 'cache-enabler' )
                 )
             )
@@ -769,12 +758,7 @@ final class Cache_Enabler {
         $items = array(
             sprintf(
                 '<a href="%s" title="%s">%s %s</a>',
-                add_query_arg(
-                    array(
-                        'page' => 'cache-enabler',
-                    ),
-                    admin_url( 'options-general.php' )
-                ),
+                admin_url( 'options-general.php?page=cache-enabler' ),
                 esc_html__( 'Disk Cache', 'cache-enabler' ),
                 ( empty( $size ) ? esc_html__( 'Empty', 'cache-enabler' ) : size_format( $size ) ),
                 esc_html__( 'Cache Size', 'cache-enabler' )
@@ -801,11 +785,7 @@ final class Cache_Enabler {
             $size = ( is_object( self::$disk ) ) ? (int) self::$disk->cache_size( CE_CACHE_DIR ) : 0;
 
             // set transient
-            set_transient(
-                'cache_size',
-                $size,
-                60 * 15
-            );
+            set_transient( 'cache_size', $size, 60 * 15 );
         }
 
         return $size;
@@ -866,9 +846,7 @@ final class Cache_Enabler {
                             ) ), '_cache__clear_nonce' ),
                 'parent' => 'top-secondary',
                 'title'  => '<span class="ab-item">' . $title . '</span>',
-                'meta'   => array(
-                                'title' => $title,
-                            ),
+                'meta'   => array( 'title' => $title ),
             )
         );
 
@@ -883,9 +861,7 @@ final class Cache_Enabler {
                                 ) ), '_cache__clear_nonce' ),
                     'parent' => 'top-secondary',
                     'title'  => '<span class="ab-item">' . esc_html__( 'Clear URL Cache', 'cache-enabler' ) . '</span>',
-                    'meta'   => array(
-                                    'title' => esc_html__( 'Clear URL Cache', 'cache-enabler' ),
-                                ),
+                    'meta'   => array( 'title' => esc_html__( 'Clear URL Cache', 'cache-enabler' ) ),
                 )
             );
         }
@@ -918,7 +894,7 @@ final class Cache_Enabler {
 
         // load if network activated
         if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
-            require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
 
         // set clear URL without query string and check if installation is in a subdirectory
@@ -1719,13 +1695,7 @@ final class Cache_Enabler {
         }
 
         // HTML tags to ignore
-        $ignore_tags = (array) apply_filters(
-            'cache_minify_ignore_tags',
-            array(
-                'textarea',
-                'pre',
-            )
-        );
+        $ignore_tags = (array) apply_filters( 'cache_minify_ignore_tags', array( 'textarea', 'pre' ) );
 
         // if selected exclude inline JavaScript
         if ( ! self::$settings['minify_inline_js'] ) {
@@ -1879,10 +1849,7 @@ final class Cache_Enabler {
             'Cache Enabler',
             'manage_options',
             'cache-enabler',
-            array(
-                __CLASS__,
-                'settings_page',
-            )
+            array( __CLASS__, 'settings_page' )
         );
     }
 
@@ -1955,12 +1922,7 @@ final class Cache_Enabler {
                     '<strong>Autoptimize</strong>',
                     sprintf(
                         '<a href="%s">%s</a>',
-                        add_query_arg(
-                            array(
-                                'page' => 'cache-enabler',
-                            ),
-                            admin_url( 'options-general.php' )
-                        ),
+                        admin_url( 'options-general.php?page=cache-enabler' ),
                         esc_html__( 'Cache Enabler Settings', 'cache-enabler' )
                     )
                 )
@@ -1979,11 +1941,7 @@ final class Cache_Enabler {
     public static function register_textdomain() {
 
         // load translated strings
-        load_plugin_textdomain(
-            'cache-enabler',
-            false,
-            'cache-enabler/lang'
-        );
+        load_plugin_textdomain( 'cache-enabler', false, 'cache-enabler/lang' );
     }
 
 
@@ -1996,14 +1954,7 @@ final class Cache_Enabler {
 
     public static function register_settings() {
 
-        register_setting(
-            'cache-enabler',
-            'cache-enabler',
-            array(
-                __CLASS__,
-                'validate_settings',
-            )
-        );
+        register_setting( 'cache-enabler', 'cache-enabler', array( __CLASS__, 'validate_settings' ) );
     }
 
 
@@ -2114,6 +2065,9 @@ final class Cache_Enabler {
 
     public static function settings_page() {
 
+        // get Cache Enabler settings
+        $settings = self::$settings;
+
         ?>
 
         <div id="cache-enabler-settings" class="wrap">
@@ -2148,7 +2102,6 @@ final class Cache_Enabler {
 
             <form method="post" action="options.php">
                 <?php settings_fields( 'cache-enabler' ); ?>
-                <?php $settings = self::_get_settings(); ?>
                 <table class="form-table">
                     <tr valign="top">
                         <th scope="row">

--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -1,18 +1,15 @@
 <?php
-
-
-// exit
-defined( 'ABSPATH' ) || exit;
-
-
 /**
  * Interact with Cache Enabler.
  *
  * @since  1.3.5
  */
 
-class Cache_Enabler_CLI {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
+class Cache_Enabler_CLI {
 
     /**
      * Clear the page cache.

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1,18 +1,15 @@
 <?php
-
-
-// exit
-defined( 'ABSPATH' ) || exit;
-
-
 /**
- * Cache_Enabler_Disk
+ * Cache Enabler disk handling
  *
  * @since  1.0.0
  */
 
-final class Cache_Enabler_Disk {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
+final class Cache_Enabler_Disk {
 
     /**
      * cached filename settings
@@ -209,7 +206,7 @@ final class Cache_Enabler_Disk {
      * create signature
      *
      * @since   1.0.0
-     * @change  1.0.0
+     * @change  1.5.0
      *
      * @return  string  signature
      */
@@ -217,7 +214,7 @@ final class Cache_Enabler_Disk {
     private static function _cache_signature() {
 
         return sprintf(
-            "\n\n<!-- %s @ %s",
+            '<!-- %s @ %s',
             'Cache Enabler by KeyCDN',
             date_i18n(
                 'd.m.Y H:i:s',


### PR DESCRIPTION
Update code base formatting:

* Update hooks and various functions to be one liners.

* Update logic for exiting if directly accessed.

* Update associative arrays. If it only has one key and value it does not need to start on a new line (corrects this change introduced in PR #84).

* Remove unnecessary parentheses from `require_once` (language constructs, not function calls).

* Remove unnecessary `add_query_arg()` functions.

Update `Cache_Enabler_Disk::_cache_signature()` to not have two newlines. Instead, insert the Cache Enabler HTML comment directly after the HTML page.