### PR TITLE
update cache engine

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -3,7 +3,7 @@
  * Cache Enabler advanced cache
  *
  * @since   1.2.0
- * @change  1.5.0
+ * @change  1.5.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,5 +15,5 @@ $ce_dir = ( ( defined( 'WP_PLUGIN_DIR' ) ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/
 require_once $ce_dir . '/inc/cache_enabler_engine.class.php';
 require_once $ce_dir . '/inc/cache_enabler_disk.class.php';
 
-$cache_engine = new Cache_Enabler_Engine;
-$cache_engine->deliver_cache();
+Cache_Enabler_Engine::start();
+Cache_Enabler_Engine::deliver_cache();

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -25,20 +25,25 @@ final class Cache_Enabler {
 
 
     /**
+     * settings from database (deprecated)
+     *
+     * @deprecated  1.5.0
+     */
+
+    public static $options;
+
+
+    /**
      * constructor
      *
      * @since   1.0.0
-     * @change  1.5.0
+     * @change  1.5.2
      */
 
     public function __construct() {
 
-        // check if engine is running
-        if ( ! Cache_Enabler_Engine::$started ) {
-            new Cache_Enabler_Engine;
-        }
-
         // init hooks
+        add_action( 'init', array( 'Cache_Enabler_Engine', 'start' ) );
         add_action( 'init', array( 'Cache_Enabler_Engine', 'start_buffering' ) );
         add_action( 'init', array( __CLASS__, 'process_clear_cache_request' ) );
         add_action( 'init', array( __CLASS__, 'register_textdomain' ) );
@@ -265,7 +270,7 @@ final class Cache_Enabler {
      * update backend requirements
      *
      * @since   1.5.0
-     * @change  1.5.1
+     * @change  1.5.2
      *
      * @param   $plugin_update     whether or not an update is in progress
      * @return  $new_option_value  new or current database option value

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -16,7 +16,6 @@ final class Cache_Enabler_Disk {
      *
      * @since   1.5.0
      * @change  1.5.0
-     *
      */
 
     public static $cache_dir = WP_CONTENT_DIR . '/cache/cache-enabler';
@@ -27,7 +26,6 @@ final class Cache_Enabler_Disk {
      *
      * @since   1.5.0
      * @change  1.5.0
-     *
      */
 
     private static $settings_dir = WP_CONTENT_DIR . '/settings/cache-enabler';

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,9 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.5.2 =
 
+* Update late cache engine start to be on the `init` hook instead of `plugins_loaded` (#153)
+* Add deprecated variable that was previously deleted to improve backwards compatibility (#153)
+* Fix WP-CLI notice errors (#153)
 * Fix creating settings file on plugin update
 
 = 1.5.1 =


### PR DESCRIPTION
Update cache delivery to not check if the cache has expired as this is already done previously in the stack (when the engine is starting). Having this additional check is not currently required with having the cache delivery only called in the `advanced-cache.php` drop-in.

Update late cache engine start to be on the `init` hook instead of `plugins_loaded` when the plugin is initialized (#152).

Add cache engine start check to see whether or not the cache engine should be started, moving checking if the request is an Ajax, REST API, or XMLRPC to this method instead to prevent unnecessary engine starts. This fixes the undefined index notice errors when using any WP-CLI command (#152).

Add deprecated variable that was previously deleted in version 1.5.0 to improve backwards compatibility (nosilver4u/ewww-image-optimizer#199). 

Fixes #152