### PR TITLE
update cache engine

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1792,7 +1792,7 @@ final class Cache_Enabler {
                                     <input name="cache_enabler[excluded_query_strings]" type="text" id="excluded_query_strings" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_query_strings'] ) ?>" class="regular-text code" />
                                     <p class="description"><?php esc_html_e( 'A regex matching query strings that should bypass the cache.', 'cache-enabler' ); ?></p>
                                     <p><?php esc_html_e( 'Example:', 'cache-enabler' ); ?> <code class="code--form-control">/^nocache$/</code></p>
-                                    <p><?php esc_html_e( 'Default if unset:', 'cache-enabler' ); ?> <code class="code--form-control">/^(?!(fbclid|ref|mc_(cid|eid)|utm_(source|medium|campaign|term|content|expid)|gclid|fb_(action_ids|action_types|source)|age-verified|ao_noptimize|usqp|cn-reloaded|_ga|_ke)).+$/</code></p>
+                                    <p><?php esc_html_e( 'Default if unset:', 'cache-enabler' ); ?> <code class="code--form-control">/^(?!(fbclid|ref|mc_(cid|eid)|utm_(source|medium|campaign|term|content|expid)|gclid|fb_(action_ids|action_types|source)|age-verified|usqp|cn-reloaded|_ga|_ke)).+$/</code></p>
                                 </label>
 
                                 <br />

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -58,10 +58,10 @@ final class Cache_Enabler_Engine {
 
     public function __construct() {
 
-        // get settings from disk if cache exists
+        // get settings from disk in early start if cache exists
         if ( Cache_Enabler_Disk::cache_exists() ) {
             self::$settings = Cache_Enabler_Disk::get_settings();
-        // get settings from database otherwise
+        // get settings from database in late start otherwise
         } elseif ( class_exists( 'Cache_Enabler' ) ) {
             self::$settings = Cache_Enabler::get_settings();
             // set deprecated settings
@@ -80,7 +80,7 @@ final class Cache_Enabler_Engine {
      * check if engine should start
      *
      * @since   1.5.2
-     * @change  1.5.2
+     * @change  1.5.4
      *
      * @return  boolean  true if engine should start, false otherwise
      */
@@ -92,8 +92,8 @@ final class Cache_Enabler_Engine {
             return false;
         }
 
-        // check if Ajax request
-        if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+        // check if Ajax request in early start
+        if ( defined( 'DOING_AJAX' ) && DOING_AJAX && ! class_exists( 'Cache_Enabler' ) ) {
             return false;
         }
 
@@ -109,6 +109,11 @@ final class Cache_Enabler_Engine {
 
         // check if Host request header is empty
         if ( empty( $_SERVER['HTTP_HOST'] ) ) {
+            return false;
+        }
+
+        // check request URI
+        if ( str_replace( array( '.ico', '.txt', '.xml', '.xsl' ), '', $_SERVER['REQUEST_URI'] ) !== $_SERVER['REQUEST_URI'] ) {
             return false;
         }
 
@@ -289,7 +294,7 @@ final class Cache_Enabler_Engine {
             if ( ! empty( self::$settings['excluded_query_strings'] ) ) {
                 $query_string_regex = self::$settings['excluded_query_strings'];
             } else {
-                $query_string_regex = '/^(?!(fbclid|ref|mc_(cid|eid)|utm_(source|medium|campaign|term|content|expid)|gclid|fb_(action_ids|action_types|source)|age-verified|ao_noptimize|usqp|cn-reloaded|_ga|_ke)).+$/';
+                $query_string_regex = '/^(?!(fbclid|ref|mc_(cid|eid)|utm_(source|medium|campaign|term|content|expid)|gclid|fb_(action_ids|action_types|source)|age-verified|usqp|cn-reloaded|_ga|_ke)).+$/';
             }
 
             $query_string = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_QUERY );

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,11 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 == Changelog ==
 
+= 1.5.4 =
+
+* Update default query string exclusion (#155)
+* Update cache engine start check (#155)
+
 = 1.5.3 =
 
 * Add default query string exclusion (#154)


### PR DESCRIPTION
Update cache engine to not start if the request URI contains `.ico`, `.txt`, `.xml`, or `.xsl`. This will help reduce unnecessary engine starts, especially as the WordPress files that commonly have those extensions (e.g. `robots.txt`, `sitemap.xml`, etc.) are often requested automatically by bots and are not cached anyway.

Update cache engine start to check if Ajax request only on the early start. This is still needed in the late start, like for plugin updates, and likely other cases. This will help reduce unnecessary cache checking. 

Update default query string cache exclusion that was added in PR #154 to no longer have `ao_noptimize`.