### PR TITLE
fix getting settings file edge cases

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.5.5 =
 
+* Fix getting settings file edge cases (#158)
 * Fix cache expiry
 
 = 1.5.4 =


### PR DESCRIPTION
When creating and deleting the settings file for subdirectory networks ensure the blog path is always chosen by getting the last directory. Improve the fallback handling to fix certain edge cases when getting the settings from the settings file. In most cases the current default way of getting the settings file when in the early start of the cache engine is successful, however, in some edge cases the settings file will not be found (resulting in the cached pages not being delivered).

Fixes #157