### PR TITLE
update advanced cache

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -3,7 +3,7 @@
  * Cache Enabler advanced cache
  *
  * @since   1.2.0
- * @change  1.5.2
+ * @change  1.5.5
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -11,9 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $ce_dir = ( ( defined( 'WP_PLUGIN_DIR' ) ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins' ) . '/cache-enabler';
+$ce_engine_file = $ce_dir . '/inc/cache_enabler_engine.class.php';
+$ce_disk_file   = $ce_dir . '/inc/cache_enabler_disk.class.php';
 
-require_once $ce_dir . '/inc/cache_enabler_engine.class.php';
-require_once $ce_dir . '/inc/cache_enabler_disk.class.php';
+if ( file_exists( $ce_engine_file ) && file_exists( $ce_disk_file ) ) {
+    require_once $ce_engine_file;
+    require_once $ce_disk_file;
+}
 
-Cache_Enabler_Engine::start();
-Cache_Enabler_Engine::deliver_cache();
+if ( class_exists( 'Cache_Enabler_Engine' ) ) {
+    Cache_Enabler_Engine::start();
+    Cache_Enabler_Engine::deliver_cache();
+}

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 
 = 1.5.5 =
 
+* Update advanced cache to prevent potential errors (#161)
 * Update getting settings to create settings file if cache exists but settings file does not (#159)
 * Fix getting settings file edge cases (#158)
 * Fix cache expiry


### PR DESCRIPTION
Update advanced cache to check if the files exist before requiring them and if the `Cache_Enabler_Engine` class exists before calling the static methods. This will prevent potential errors, like if the Cache Enabler plugin is manually deleted (e.g. going to the plugins directory and deleting `cache-enabler`).