### PR TITLE
update cache size and clearing

### DIFF
--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -61,7 +61,7 @@ class Cache_Enabler_CLI {
         if ( empty( $assoc_args['ids'] ) && empty( $assoc_args['urls'] ) && empty( $assoc_args['sites'] ) ) {
             Cache_Enabler::clear_complete_cache();
 
-            return WP_CLI::success( ( is_multisite() && is_plugin_active_for_network( CE_BASE ) ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Cache cleared.', 'cache-enabler' ) );
+            return WP_CLI::success( ( is_multisite() ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Cache cleared.', 'cache-enabler' ) );
         }
 
         // clear page(s) cache by post ID(s) and/or URL(s)

--- a/readme.txt
+++ b/readme.txt
@@ -81,34 +81,31 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.6.0 =
-
+* Fix getting cache size for main site in subdirectory network (#164)
+* Fix deleting cache size transient (#164)
+* Fix cache clearing edge case (#164)
 * Fix clear cache request validation
 
 = 1.5.5 =
-
 * Update advanced cache to prevent potential errors (#161)
 * Update getting settings to create settings file if cache exists but settings file does not (#159)
 * Fix getting settings file edge cases (#158)
 * Fix cache expiry
 
 = 1.5.4 =
-
 * Update default query string exclusion (#155)
 * Update cache engine start check (#155)
 
 = 1.5.3 =
-
 * Add default query string exclusion (#154)
 
 = 1.5.2 =
-
 * Update late cache engine start to be on the `init` hook instead of `plugins_loaded` (#153)
 * Add deprecated variable that was previously deleted to improve backwards compatibility (#153)
 * Fix WP-CLI notice errors (#153)
 * Fix creating settings file on plugin update
 
 = 1.5.1 =
-
 * Fix getting settings file
 
 = 1.5.0 =


### PR DESCRIPTION
Add `Cache_Enabler_Disk::get_site_objects()` to get the file system objects of a specific site. In most cases getting the site objects is as simple as getting the directory objects in the site directory, however, it needs to be filtered if the main site in a subdirectory network. This is because all other sites objects are stored in the main site directory too. This will fix the edge case of clearing the complete network cache when clearing the main site in a subdirectory network installed in a subdirectory. This will also fix getting the cache size for the main site in a subdirectory network (completing what was mentioned in PR #147).

Update `Cache_Enabler::clear_site_cache_by_blog_id()` to work for both single and multisites to allow the site cache of a single site to be cleared with this method. This can be done by using `1`, which is returned when using `get_current_blog_id()` in a single site installation. Use `Cache_Enabler_Disk::get_site_objects()` to get the page(s) that need to be cleared. When deleting the cache size transient in a multisite installation switch to the blog ID provided to always ensure the correct transient is deleted. This fixes the case where the cache size transient of the main site would always be deleted when clearing the site cache through WP-CLI, regardless of the site(s) cleared.

Update `Cache_Enabler::clear_complete_cache()` to delete all cache size transients instead of only the main site. This fixes the issue where the cache size transient was not being deleted for all other sites when clearing the network cache.

Update `Cache_Enabler::get_cache_size_transient_name()` to not include the blog ID in the name as this is actually not required as the transient will be stored in the applicable site options table. Removing it prevents having to update methods to allow the blog ID to be included when this is called in `Cache_Enabler::clear_complete_cache()`.

Update `Cache_Enabler_Disk::clear_cache()` to check if the directory exists before trying to clear it.

Update returned success message for multisites when clearing the complete cache with WP-CLI. Show the network has been cleared regardless if network activated because the entire network is actually cleared either way.

Remove the `is_file()` check from `Cache_Enabler_Disk::cache_file_dir_path()` because with the updates made to `Cache_Enabler::clear_site_cache_by_blog_id()` it will be triggered in nearly all cases when the site cache is cleared. I have been unable to identify what the purpose of this was for because the cache will not be delivered if the file is not readable (if two files were concatenated when getting the cache that file would not exist or be readable).