### PR TITLE
add site cache clearing

### DIFF
--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -61,7 +61,7 @@ class Cache_Enabler_CLI {
         if ( empty( $assoc_args['ids'] ) && empty( $assoc_args['urls'] ) && empty( $assoc_args['sites'] ) ) {
             Cache_Enabler::clear_complete_cache();
 
-            return WP_CLI::success( ( is_multisite() ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Cache cleared.', 'cache-enabler' ) );
+            return WP_CLI::success( ( is_multisite() ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Site cache cleared.', 'cache-enabler' ) );
         }
 
         // clear page(s) cache by post ID(s) and/or URL(s)

--- a/readme.txt
+++ b/readme.txt
@@ -81,9 +81,10 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.6.0 =
+* Add site cache clearing behavior (#167)
 * Fix getting cache size for main site in subdirectory network (#164)
 * Fix deleting cache size transient (#164)
-* Fix cache clearing edge case (#164)
+* Fix cache clearing (#164 and #167)
 * Fix clear cache request validation
 
 = 1.5.5 =


### PR DESCRIPTION
Add cache clearing behavior to clear the site cache. Update most places with this new behavior instead of clearing the complete cache. This fixes a couple issues in multisite networks, like how the settings for one site can clear the complete network cache, regardless of how other sites are configured. The same could happen when choosing to clear the cache when saving the settings on any site in the network. The changes introduced to `Cache_Enabler::clear_site_cache_by_blog_id()` in PR #164 allows this to be handled in one way for both single and multisite installations. This change will reduce how often the `ce_action_cache_cleared` action hook is being fired, however, the upcoming hook changes will take this into account and will improve indicating what has actually been cleared.

Remove clearing the cache from `Cache_Enabler::on_uninstall()` because this is done on plugin deactivation.

Remove error control operator when scanning the directory in `Cache_Enabler_Disk::get_dir_objects()` because checking if the directory exists now always occurs before this method is called. This has not been added to the method itself as there are currently a few methods that rely on whether or not the directory about to be scanned exists.