### PR TITLE
update output buffering timing to start earlier

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -3,7 +3,7 @@
  * Cache Enabler advanced cache
  *
  * @since   1.2.0
- * @change  1.5.5
+ * @change  1.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,6 +20,13 @@ if ( file_exists( $ce_engine_file ) && file_exists( $ce_disk_file ) ) {
 }
 
 if ( class_exists( 'Cache_Enabler_Engine' ) ) {
-    Cache_Enabler_Engine::start();
-    Cache_Enabler_Engine::deliver_cache();
+    $ce_engine_started = Cache_Enabler_Engine::start();
+
+    if ( $ce_engine_started ) {
+        $ce_cache_delivered = Cache_Enabler_Engine::deliver_cache();
+
+        if ( ! $ce_cache_delivered ) {
+            Cache_Enabler_Engine::start_buffering();
+        }
+    }
 }

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -44,7 +44,6 @@ final class Cache_Enabler {
 
         // init hooks
         add_action( 'init', array( 'Cache_Enabler_Engine', 'start' ) );
-        add_action( 'init', array( 'Cache_Enabler_Engine', 'start_buffering' ) );
         add_action( 'init', array( __CLASS__, 'process_clear_cache_request' ) );
         add_action( 'init', array( __CLASS__, 'register_textdomain' ) );
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -766,7 +766,7 @@ final class Cache_Enabler_Disk {
             }
         }
 
-        // create settings file if cache exists but settings file does not
+        // create settings file if it does not exist and in late engine start
         if ( empty( $settings ) && class_exists( 'Cache_Enabler' ) ) {
             self::create_settings_file( Cache_Enabler::get_settings() );
         }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.6.0 =
+* Update output buffer timing to start earlier on the `advanced-cache.php` drop-in instead of the `init` hook (#168)
 * Add site cache clearing behavior (#167)
 * Fix getting cache size for main site in subdirectory network (#164)
 * Fix deleting cache size transient (#164)


### PR DESCRIPTION
Updated output buffering to start even earlier on the `advanced-cache.php` drop-in instead of the `init` hook. This builds upon what was added in PR #137 and became possible with the cache engine introduced in PR #147. While the previous changes introduced increased the compatibility with other plugins (#78) it turns out starting on the `init` hook with the default priority still has compatibility issues with some plugins that start earlier (#120). Since delivering the cache requires the `advanced-cache.php` drop-in, which itself relies on the `WP_CACHE` constant being defined as `true`, as well as the settings file existing, it also makes sense for page caching to rely on both as well. This is the earliest Cache Enabler can start the output buffering, which should prevent any issues like this arising in the future.

The following updates to the caching process were updated because of this change:

* The first attempt at trying to start the cache engine will now rely on whether or not the request script is the core WordPress index file instead of if the cached page exists. This will make it so if the settings file exists no database query will be made when getting the settings to cache a page. This became possible with the PHP settings file introduced in PR #147 because all settings are now available in this file. This updates #159 when creating the settings file if it does not exist in the late cache engine start. Instead, the first request would generate the settings file, the second request would cache the page, and the third request would deliver the cached page.

* Update checking if the installation directory index received from `$_SERVER['SCRIPT_NAME']` is `/index.php` instead of any `index.php` file as we want the actual installation directory index file. This will ensure Cache Enabler is only starting the cache engine on frontend pages that would end up being cached and delivered, and not pages like `/wp-admin/index.php` (which would bypass the cache by the `is_admin()` conditional tag).