### PR TITLE
update cache clearing for comment actions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.6.0 =
+* Update cache clearing behavior for comment actions to prevent unnecessary cache clearing (#169)
 * Add site cache clearing behavior (#167)
 * Fix getting cache size for main site in subdirectory network (#164)
 * Fix deleting cache size transient (#164)


### PR DESCRIPTION
Update cache clearing behavior for comment actions to prevent unnecessary cache clearing. When editing a comment only clear the cache if the comment is approved. When the comment status changes only clear the cache if from or to approved.