### PR TITLE
update site cache clearing

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1340,7 +1340,7 @@ final class Cache_Enabler {
      * clear site cache by blog ID
      *
      * @since   1.4.0
-     * @change  1.6.0
+     * @change  1.6.1
      *
      * @param   integer|string  $blog_id                      blog ID
      * @param   boolean         $delete_cache_size_transient  whether or not the cache size transient should be deleted
@@ -1363,11 +1363,16 @@ final class Cache_Enabler {
             return;
         }
 
+        // ensure site cache being cleared is current blog
+        if ( is_multisite() ) {
+            switch_to_blog( $blog_id );
+        }
+
         // disable page cache cleared hook
         self::$fire_page_cache_cleared_hook = false;
 
         // get site URL
-        $site_url = get_home_url( $blog_id );
+        $site_url = home_url();
 
         // get site objects
         $site_objects = Cache_Enabler_Disk::get_site_objects( $site_url );
@@ -1382,13 +1387,12 @@ final class Cache_Enabler {
 
         // delete cache size transient
         if ( $delete_cache_size_transient ) {
-            if ( is_multisite() ) {
-                switch_to_blog( $blog_id );
-                delete_transient( self::get_cache_size_transient_name() );
-                restore_current_blog();
-            } else {
-                delete_transient( self::get_cache_size_transient_name() );
-            }
+            delete_transient( self::get_cache_size_transient_name() );
+        }
+
+        // restore current blog from before site cache being cleared
+        if ( is_multisite() ) {
+            restore_current_blog();
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,8 @@ When combined with Optimus, the WordPress Cache Enabler allows you to easily del
 == Changelog ==
 
 = 1.6.1 =
-* Fix cache clearing on WooCommerce stock update (#179)
+* Update site cache clearing behavior for multisite networks to ensure cache cleared action hooks are fired when using WP-CLI or clear cache action hooks (#180)
+* Fix cache clearing behavior on WooCommerce stock update (#179)
 
 = 1.6.0 =
 * Update cache clearing behavior for multisite networks when permalink structure has changed to prevent unnecessary cache clearing (#170)


### PR DESCRIPTION
Update site cache clearing to switch to blog before site cache is cleared. In most cases we will already be in the current blog due to how the `Cache_Enabler::each_site()` method functions, but this will fix the known issue for multisite networks discussed in PR #170 where some cache cleared hooks would not be fired or the values would be empty. This would occur when using the WP-CLI `clear` subcommand with the `--sites` option or the public clear cache hooks like `cache_enabler_clear_site_cache_by_blog_id` when the blog ID being cleared is not the main site.