### PR TITLE
update HTML minification

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,7 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 == Changelog ==
 
 = 1.6.1 =
+* Update HTML minification to remove CSS and JavaScript comments (#184)
 * Update site cache clearing behavior for multisite networks to ensure cache cleared action hooks are fired when using WP-CLI or clear cache action hooks (#180)
 * Add `cache_enabler_convert_webp_attributes` and `cache_enabler_convert_webp_ignore_query_strings` filter hooks (#183)
 * Fix cache clearing behavior on WooCommerce stock update (#179)


### PR DESCRIPTION
Update HTML minification to remove CSS and JavaScript comments. This will fix the issue where in certain cases JavaScript comments would cause the entire inline script to be commented out.

Update HTML minification regular expression for improved handling. This removes unnecessary checks, which will make it slightly faster.