### PR TITLE
Explicitly chmod the cache and settings directories

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[{*.md,*.yml}]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[{*.md,*.yml}]
+[*.md]
 trim_trailing_whitespace = false

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -483,7 +483,7 @@ final class Cache_Enabler_Disk {
         $new_settings_file = self::get_settings_file();
 
         // make directory if necessary
-        if ( ! self::mkdir_p( dirname( self::get_settings_file() ) ) ) {
+        if ( ! self::mkdir_p( dirname( $new_settings_file ) ) ) {
             wp_die( 'Unable to create directory.' );
         }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -372,7 +372,7 @@ final class Cache_Enabler_Disk {
         $cache_signature = self::cache_signature();
 
         // make directory if necessary
-        if ( ! wp_mkdir_p( self::cache_file_dir_path() ) ) {
+        if ( ! self::mkdir_p( self::cache_file_dir_path() ) ) {
             wp_die( 'Unable to create directory.' );
         }
 
@@ -483,7 +483,7 @@ final class Cache_Enabler_Disk {
         $new_settings_file = self::get_settings_file();
 
         // make directory if necessary
-        if ( ! wp_mkdir_p( dirname( $new_settings_file ) ) ) {
+        if ( ! self::mkdir_p( dirname( self::get_settings_file() ) ) ) {
             wp_die( 'Unable to create directory.' );
         }
 
@@ -1138,6 +1138,94 @@ final class Cache_Enabler_Disk {
         @rmdir( self::$settings_dir );
     }
 
+    /**
+     * Get the current WP Filesystem instance.
+     *
+     * If it has not yet been initialized, do so and cache the result.
+     *
+     * @throws \RuntimeException if the filesystem could not be initialized.
+     *
+     * @global $wp_filesystem
+     *
+     * @return \WP_Filesystem_Base
+     */
+    public static function get_filesystem() {
+        global $wp_filesystem;
+
+        // We already have an instance, so return early.
+        if ( $wp_filesystem instanceof WP_Filesystem_Base ) {
+            return $wp_filesystem;
+        }
+
+        try {
+            require_once ABSPATH . '/wp-admin/includes/file.php';
+
+            $filesystem = WP_Filesystem();
+
+            if ( null === $filesystem ) {
+                throw new \RuntimeException( 'The provided filesystem method is unavailable.' );
+            }
+
+            if ( false === $filesystem ) {
+                if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
+                    throw new \RuntimeException(
+                        $wp_filesystem->get_error_message,
+                        is_numeric( $wp_error->get_error_code() ) ? (int) $wp_error->get_error_code() : 0
+                    );
+                }
+
+                throw new \RuntimeException( 'Unspecified failure.' );
+            }
+
+            if ( ! is_object( $wp_filesystem ) || ! $wp_filesystem instanceof WP_Filesystem_Base ) {
+                throw new \RuntimeException( '$wp_filesystem is not an instance of WP_Filesystem_Base' );
+            }
+        } catch ( \Exception $e ) {
+            throw new \RuntimeException(
+                sprintf( 'There was an error initializing the WP_Filesystem class: %1$s', $e->getMessage() ),
+                $e->getCode(),
+                $e
+            );
+        }
+
+        return $wp_filesystem;
+    }
+
+    /**
+     * Create a directory to be used by the plugin.
+     *
+     * This method assumes that the directory (and its parent) should have 755 permissions, and
+     * will attempt to update any existing directories accordingly.
+     *
+     * @param string $path The path to construct.
+     *
+     * @return bool True if the directory either already exists or was created *and* has the
+     *              correct permissions, false otherwise.
+     */
+    private static function mkdir_p( $path ) {
+        $parent = dirname( $path );
+        $fs     = self::get_filesystem();
+
+        // Everything is as it should be.
+        if ( $fs->is_dir( $path ) && '755' === $fs->getchmod( $path ) && '755' === $fs->getchmod( $parent ) ) {
+            return true;
+        }
+
+        // Create any directories that don't yet exist.
+        if ( ! wp_mkdir_p( $path ) ) {
+            return false;
+        }
+
+        if ( '755' !== $fs->getchmod( $parent ) ) {
+            return $fs->chmod( $parent, 0755, true );
+        }
+
+        if ( '755' !== $fs->getchmod( $path ) ) {
+            return $fs->chmod( $path, 0755 );
+        }
+
+        return true;
+    }
 
     /**
      * delete asset (deprecated)

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1149,6 +1149,7 @@ final class Cache_Enabler_Disk {
      *
      * @return \WP_Filesystem_Base
      */
+
     public static function get_filesystem() {
         global $wp_filesystem;
 
@@ -1162,11 +1163,11 @@ final class Cache_Enabler_Disk {
 
             $filesystem = WP_Filesystem();
 
-            if ( null === $filesystem ) {
+            if ( $filesystem === null ) {
                 throw new \RuntimeException( 'The provided filesystem method is unavailable.' );
             }
 
-            if ( false === $filesystem ) {
+            if ( $filesystem === false ) {
                 if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
                     throw new \RuntimeException(
                         $wp_filesystem->get_error_message,
@@ -1202,12 +1203,13 @@ final class Cache_Enabler_Disk {
      * @return bool True if the directory either already exists or was created *and* has the
      *              correct permissions, false otherwise.
      */
+
     private static function mkdir_p( $path ) {
         $parent = dirname( $path );
         $fs     = self::get_filesystem();
 
         // Everything is as it should be.
-        if ( $fs->is_dir( $path ) && '755' === $fs->getchmod( $path ) && '755' === $fs->getchmod( $parent ) ) {
+        if ( $fs->is_dir( $path ) && $fs->getchmod( $path ) === '755' && $fs->getchmod( $parent ) === '755' ) {
             return true;
         }
 
@@ -1216,11 +1218,11 @@ final class Cache_Enabler_Disk {
             return false;
         }
 
-        if ( '755' !== $fs->getchmod( $parent ) ) {
+        if ( $fs->getchmod( $parent ) === '755' ) {
             return $fs->chmod( $parent, 0755, true );
         }
 
-        if ( '755' !== $fs->getchmod( $path ) ) {
+        if ( $fs->getchmod( $path ) === '755' ) {
             return $fs->chmod( $path, 0755 );
         }
 


### PR DESCRIPTION
[The `wp_mkdir_p()` function](https://developer.wordpress.org/reference/functions/wp_mkdir_p/) will create new directories recursively based on the permissions of the parent directory; in the case of this plugin, `wp-content/`.

Unfortunately, that function _doesn't_ expose a way to explicitly specify permissions, so a locked-down `wp-content/` directory can result in the directories being created with permissions that don't allow the web server to serve the files.

This PR introduces a new `Cache_Enabler_Disk::mkdir_p()` method, which recursively creates the directories **and** ensures that the newly-created directory has `0755` permissions, meaning `/cache`, `/cache/cache-enabler`, `/settings`, and `/settings/cache-enabler` will all explicitly be given `0755`.

Fixes #193.