### PR TITLE
clean code base

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -10,7 +10,7 @@ Version: 1.6.2
 */
 
 /*
-Copyright (C) 2020 KeyCDN
+Copyright (C) 2021 KeyCDN
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -252,9 +252,9 @@ final class Cache_Enabler {
      * add or update backend requirements
      *
      * @since   1.5.0
-     * @change  1.6.0
+     * @change  1.7.0
      *
-     * @return  $new_option_value  new or current database option value
+     * @return  array  $new_option_value  new or current database option value
      */
 
     public static function update_backend() {
@@ -280,6 +280,9 @@ final class Cache_Enabler {
 
         // merge defined settings into default settings
         $new_option_value = wp_parse_args( $old_option_value, self::get_default_settings() );
+
+        // validate settings
+        $new_option_value = self::validate_settings( $new_option_value );
 
         // add or update database option
         update_option( 'cache_enabler', $new_option_value );
@@ -407,7 +410,7 @@ final class Cache_Enabler {
         $settings = get_option( 'cache_enabler' );
 
         // if database option does not exist or settings are outdated
-        if ( $settings === false || isset( $settings['version'] ) && $settings['version'] !== CACHE_ENABLER_VERSION ) {
+        if ( $settings === false || ! isset( $settings['version'] ) || $settings['version'] !== CACHE_ENABLER_VERSION ) {
             $settings = self::update_backend();
         }
 
@@ -595,14 +598,14 @@ final class Cache_Enabler {
             'clear_site_cache_on_saved_post'     => 0,
             'clear_site_cache_on_saved_comment'  => 0,
             'clear_site_cache_on_changed_plugin' => 0,
-            'compress_cache'                     => 0,
             'convert_image_urls_to_webp'         => 0,
+            'compress_cache'                     => 0,
+            'minify_html'                        => 0,
+            'minify_inline_css_js'               => 0,
             'excluded_post_ids'                  => '',
             'excluded_page_paths'                => '',
             'excluded_query_strings'             => '',
             'excluded_cookies'                   => '',
-            'minify_html'                        => 0,
-            'minify_inline_css_js'               => 0,
         );
 
         // merge default settings
@@ -650,8 +653,8 @@ final class Cache_Enabler {
             'update_product_stock'                   => '', // deprecated
             'new_comment'                            => 'clear_site_cache_on_saved_comment',
             'clear_on_upgrade'                       => 'clear_site_cache_on_changed_plugin',
-            'compress'                               => 'compress_cache',
             'webp'                                   => 'convert_image_urls_to_webp',
+            'compress'                               => 'compress_cache',
             'excl_ids'                               => 'excluded_post_ids',
             'excl_paths'                             => 'excluded_page_paths',
             'excl_cookies'                           => 'excluded_cookies',
@@ -671,6 +674,7 @@ final class Cache_Enabler {
                 if ( ! empty( $new_name ) ) {
                     $settings[ $new_name ] = $settings[ $old_name ];
                 }
+
                 unset( $settings[ $old_name ] );
             }
         }
@@ -683,7 +687,7 @@ final class Cache_Enabler {
      * add plugin action links in the plugins list table
      *
      * @since   1.0.0
-     * @change  1.5.0
+     * @change  1.7.0
      *
      * @param   array  $action_links  action links
      * @return  array  $action_links  updated action links if applicable, unchanged otherwise
@@ -696,17 +700,12 @@ final class Cache_Enabler {
             return $action_links;
         }
 
-        // append action link
-        $action_links = wp_parse_args(
-            array(
-                sprintf(
-                    '<a href="%s">%s</a>',
-                    admin_url( 'options-general.php?page=cache-enabler' ),
-                    esc_html__( 'Settings', 'cache-enabler' )
-                )
-            ),
-            $action_links
-        );
+        // prepend action link
+        array_unshift( $action_links, sprintf(
+            '<a href="%s">%s</a>',
+            admin_url( 'options-general.php?page=cache-enabler' ),
+            esc_html__( 'Settings', 'cache-enabler' )
+        ) );
 
         return $action_links;
     }
@@ -783,7 +782,7 @@ final class Cache_Enabler {
      * @since   1.0.0
      * @change  1.6.0
      *
-     * @param   object  menu properties
+     * @param   object  $wp_admin_bar  menu properties
      */
 
     public static function add_admin_bar_items( $wp_admin_bar ) {
@@ -937,7 +936,7 @@ final class Cache_Enabler {
      * admin notice after cache has been cleared
      *
      * @since   1.0.0
-     * @change  1.6.0
+     * @change  1.7.0
      */
 
     public static function cache_cleared_notice() {
@@ -948,7 +947,7 @@ final class Cache_Enabler {
         }
 
         if ( get_transient( self::get_cache_cleared_transient_name() ) ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-success is-dismissible"><p><strong>%s</strong></p></div>',
                 ( is_multisite() && is_network_admin() ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Site cache cleared.', 'cache-enabler' )
             );
@@ -1459,7 +1458,7 @@ final class Cache_Enabler {
 
         // check PHP version
         if ( version_compare( PHP_VERSION, CACHE_ENABLER_MIN_PHP, '<' ) ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-error"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Cache Enabler 2. PHP version (e.g. 5.6)
@@ -1472,7 +1471,7 @@ final class Cache_Enabler {
 
         // check WordPress version
         if ( version_compare( $GLOBALS['wp_version'], CACHE_ENABLER_MIN_WP . 'alpha', '<' ) ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-error"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Cache Enabler 2. WordPress version (e.g. 5.1)
@@ -1485,7 +1484,7 @@ final class Cache_Enabler {
 
         // check advanced-cache.php drop-in
         if ( ! file_exists( WP_CONTENT_DIR . '/advanced-cache.php' ) ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Cache Enabler 2. advanced-cache.php 3. wp-content/plugins/cache-enabler 4. wp-content
@@ -1500,7 +1499,7 @@ final class Cache_Enabler {
 
         // check permalink structure
         if ( Cache_Enabler_Engine::$settings['permalink_structure'] === 'plain' && current_user_can( 'manage_options' ) ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Cache Enabler 2. Permalink Settings
@@ -1517,7 +1516,7 @@ final class Cache_Enabler {
 
         // check file permissions
         if ( file_exists( dirname( Cache_Enabler_Disk::$cache_dir ) ) && ! is_writable( dirname( Cache_Enabler_Disk::$cache_dir ) ) ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Cache Enabler 2. 755 3. wp-content/cache 4. file permissions
@@ -1536,7 +1535,7 @@ final class Cache_Enabler {
 
         // check Autoptimize HTML optimization
         if ( defined( 'AUTOPTIMIZE_PLUGIN_DIR' ) && Cache_Enabler_Engine::$settings['minify_html'] && get_option( 'autoptimize_html', '' ) !== '' ) {
-            echo sprintf(
+            printf(
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Autoptimize 2. Cache Enabler Settings
@@ -1614,7 +1613,7 @@ final class Cache_Enabler {
      * validate settings
      *
      * @since   1.0.0
-     * @change  1.6.1
+     * @change  1.7.0
      *
      * @param   array  $settings            user defined settings
      * @return  array  $validated_settings  validated settings
@@ -1622,25 +1621,20 @@ final class Cache_Enabler {
 
     public static function validate_settings( $settings ) {
 
-        // validate array
-        if ( ! is_array( $settings ) ) {
-            return;
-        }
-
         $validated_settings = array(
             'cache_expires'                      => (int) ( ! empty( $settings['cache_expires'] ) ),
-            'cache_expiry_time'                  => (int) @$settings['cache_expiry_time'],
+            'cache_expiry_time'                  => (int) $settings['cache_expiry_time'],
             'clear_site_cache_on_saved_post'     => (int) ( ! empty( $settings['clear_site_cache_on_saved_post'] ) ),
             'clear_site_cache_on_saved_comment'  => (int) ( ! empty( $settings['clear_site_cache_on_saved_comment'] ) ),
             'clear_site_cache_on_changed_plugin' => (int) ( ! empty( $settings['clear_site_cache_on_changed_plugin'] ) ),
-            'compress_cache'                     => (int) ( ! empty( $settings['compress_cache'] ) ),
             'convert_image_urls_to_webp'         => (int) ( ! empty( $settings['convert_image_urls_to_webp'] ) ),
-            'excluded_post_ids'                  => (string) sanitize_text_field( @$settings['excluded_post_ids'] ),
-            'excluded_page_paths'                => (string) self::validate_regex( @$settings['excluded_page_paths'] ),
-            'excluded_query_strings'             => (string) self::validate_regex( @$settings['excluded_query_strings'] ),
-            'excluded_cookies'                   => (string) self::validate_regex( @$settings['excluded_cookies'] ),
+            'compress_cache'                     => (int) ( ! empty( $settings['compress_cache'] ) ),
             'minify_html'                        => (int) ( ! empty( $settings['minify_html'] ) ),
             'minify_inline_css_js'               => (int) ( ! empty( $settings['minify_inline_css_js'] ) ),
+            'excluded_post_ids'                  => (string) sanitize_text_field( $settings['excluded_post_ids'] ),
+            'excluded_page_paths'                => (string) self::validate_regex( $settings['excluded_page_paths'] ),
+            'excluded_query_strings'             => (string) self::validate_regex( $settings['excluded_query_strings'] ),
+            'excluded_cookies'                   => (string) self::validate_regex( $settings['excluded_cookies'] ),
         );
 
         // add default system settings
@@ -1660,7 +1654,7 @@ final class Cache_Enabler {
      * settings page
      *
      * @since   1.0.0
-     * @change  1.6.1
+     * @change  1.7.0
      */
 
     public static function settings_page() {
@@ -1668,9 +1662,7 @@ final class Cache_Enabler {
         ?>
 
         <div id="cache_enabler_settings" class="wrap">
-            <h2>
-                <?php esc_html_e( 'Cache Enabler Settings', 'cache-enabler' ); ?>
-            </h2>
+            <h1><?php esc_html_e( 'Cache Enabler Settings', 'cache-enabler' ); ?></h1>
 
             <?php
             if ( defined( 'WP_CACHE' ) && ! WP_CACHE ) {
@@ -1690,13 +1682,13 @@ final class Cache_Enabler {
 
             <div class="notice notice-info">
                 <p>
-                <?php
-                printf(
-                    // translators: %s: KeyCDN
-                    esc_html__( 'Combine %s with Cache Enabler for even better WordPress performance and achieve the next level of caching with a CDN.', 'cache-enabler' ),
-                    '<strong><a href="https://www.keycdn.com?utm_source=wp-admin&utm_medium=plugins&utm_campaign=cache-enabler">KeyCDN</a></strong>'
-                );
-                ?>
+                    <?php
+                    printf(
+                        // translators: %s: KeyCDN
+                        esc_html__( 'Combine Cache Enabler with %s for even better WordPress performance and achieve the next level of caching with a CDN.', 'cache-enabler' ),
+                        '<strong><a href="https://www.keycdn.com?utm_source=wp-admin&utm_medium=plugins&utm_campaign=cache-enabler" target="_blank" rel="nofollow noopener">KeyCDN</a></strong>'
+                    );
+                    ?>
                 </p>
             </div>
 
@@ -1710,15 +1702,15 @@ final class Cache_Enabler {
                         <td>
                             <fieldset>
                                 <p class="subheading"><?php esc_html_e( 'Expiration', 'cache-enabler' ); ?></p>
-                                <label for="cache_expires" class="checkbox--form-control">
-                                    <input name="cache_enabler[cache_expires]" type="checkbox" id="cache_expires" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['cache_expires'] ); ?> />
+                                <label for="cache_enabler_cache_expires" class="checkbox--form-control">
+                                    <input name="cache_enabler[cache_expires]" type="checkbox" id="cache_enabler_cache_expires" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['cache_expires'] ); ?> />
                                 </label>
-                                <label for="cache_expiry_time">
+                                <label for="cache_enabler_cache_expiry_time">
                                     <?php
                                     printf(
-                                        // translators: %s: Number of hours.
+                                        // translators: %s: Form field input for number of hours.
                                         esc_html__( 'Cached pages expire %s hours after being created.', 'cache-enabler' ),
-                                        '<input name="cache_enabler[cache_expiry_time]" type="number" id="cache_expiry_time" value="' . Cache_Enabler_Engine::$settings['cache_expiry_time'] . '" class="small-text">'
+                                        '<input name="cache_enabler[cache_expiry_time]" type="number" id="cache_enabler_cache_expiry_time" value="' . Cache_Enabler_Engine::$settings['cache_expiry_time'] . '" class="small-text">'
                                     );
                                     ?>
                                 </label>
@@ -1726,30 +1718,30 @@ final class Cache_Enabler {
                                 <br />
 
                                 <p class="subheading"><?php esc_html_e( 'Clearing', 'cache-enabler' ); ?></p>
-                                <label for="clear_site_cache_on_saved_post">
-                                    <input name="cache_enabler[clear_site_cache_on_saved_post]" type="checkbox" id="clear_site_cache_on_saved_post" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_post'] ); ?> />
+                                <label for="cache_enabler_clear_site_cache_on_saved_post">
+                                    <input name="cache_enabler[clear_site_cache_on_saved_post]" type="checkbox" id="cache_enabler_clear_site_cache_on_saved_post" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_post'] ); ?> />
                                     <?php esc_html_e( 'Clear the site cache if any post type has been published, updated, or trashed (instead of only the page and/or associated cache).', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />
 
-                                <label for="clear_site_cache_on_saved_comment">
-                                    <input name="cache_enabler[clear_site_cache_on_saved_comment]" type="checkbox" id="clear_site_cache_on_saved_comment" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_comment'] ); ?> />
+                                <label for="cache_enabler_clear_site_cache_on_saved_comment">
+                                    <input name="cache_enabler[clear_site_cache_on_saved_comment]" type="checkbox" id="cache_enabler_clear_site_cache_on_saved_comment" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_comment'] ); ?> />
                                     <?php esc_html_e( 'Clear the site cache if a comment has been posted, updated, spammed, or trashed (instead of only the page cache).', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />
 
-                                <label for="clear_site_cache_on_changed_plugin">
-                                    <input name="cache_enabler[clear_site_cache_on_changed_plugin]" type="checkbox" id="clear_site_cache_on_changed_plugin" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_changed_plugin'] ); ?> />
+                                <label for="cache_enabler_clear_site_cache_on_changed_plugin">
+                                    <input name="cache_enabler[clear_site_cache_on_changed_plugin]" type="checkbox" id="cache_enabler_clear_site_cache_on_changed_plugin" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_changed_plugin'] ); ?> />
                                     <?php esc_html_e( 'Clear the site cache if a plugin has been activated, updated, or deactivated.', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />
 
                                 <p class="subheading"><?php esc_html_e( 'Variants', 'cache-enabler' ); ?></p>
-                                <label for="convert_image_urls_to_webp">
-                                    <input name="cache_enabler[convert_image_urls_to_webp]" type="checkbox" id="convert_image_urls_to_webp" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['convert_image_urls_to_webp'] ); ?> />
+                                <label for="cache_enabler_convert_image_urls_to_webp">
+                                    <input name="cache_enabler[convert_image_urls_to_webp]" type="checkbox" id="cache_enabler_convert_image_urls_to_webp" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['convert_image_urls_to_webp'] ); ?> />
                                     <?php
                                     printf(
                                         // translators: %s: Optimus
@@ -1761,24 +1753,24 @@ final class Cache_Enabler {
 
                                 <br />
 
-                                <label for="compress_cache">
-                                    <input name="cache_enabler[compress_cache]" type="checkbox" id="compress_cache" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['compress_cache'] ); ?> />
+                                <label for="cache_enabler_compress_cache">
+                                    <input name="cache_enabler[compress_cache]" type="checkbox" id="cache_enabler_compress_cache" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['compress_cache'] ); ?> />
                                     <?php esc_html_e( 'Pre-compress cached pages with Gzip.', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />
 
                                 <p class="subheading"><?php esc_html_e( 'Minification', 'cache-enabler' ); ?></p>
-                                <label for="minify_html" class="checkbox--form-control">
-                                    <input name="cache_enabler[minify_html]" type="checkbox" id="minify_html" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['minify_html'] ); ?> />
+                                <label for="cache_enabler_minify_html" class="checkbox--form-control">
+                                    <input name="cache_enabler[minify_html]" type="checkbox" id="cache_enabler_minify_html" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['minify_html'] ); ?> />
                                 </label>
-                                <label for="minify_inline_css_js">
+                                <label for="cache_enabler_minify_inline_css_js">
                                     <?php
                                     $minify_inline_css_js_options = array(
                                         esc_html__( 'excluding', 'cache-enabler' ) => 0,
                                         esc_html__( 'including', 'cache-enabler' ) => 1,
                                     );
-                                    $minify_inline_css_js = '<select name="cache_enabler[minify_inline_css_js]" id="minify_inline_css_js">';
+                                    $minify_inline_css_js = '<select name="cache_enabler[minify_inline_css_js]" id="cache_enabler_minify_inline_css_js">';
                                     foreach ( $minify_inline_css_js_options as $key => $value ) {
                                         $minify_inline_css_js .= '<option value="' . esc_attr( $value ) . '"' . selected( $value, Cache_Enabler_Engine::$settings['minify_inline_css_js'], false ) . '>' . $key . '</option>';
                                     }
@@ -1801,13 +1793,16 @@ final class Cache_Enabler {
                         <td>
                             <fieldset>
                                 <p class="subheading"><?php esc_html_e( 'Post IDs', 'cache-enabler' ); ?></p>
-                                <label for="excluded_post_ids">
-                                    <input name="cache_enabler[excluded_post_ids]" type="text" id="excluded_post_ids" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_post_ids'] ) ?>" class="regular-text" />
+                                <label for="cache_enabler_excluded_post_ids">
+                                    <input name="cache_enabler[excluded_post_ids]" type="text" id="cache_enabler_excluded_post_ids" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_post_ids'] ) ?>" class="regular-text" />
                                     <p class="description">
-                                    <?php
-                                    // translators: %s: ,
-                                    printf( esc_html__( 'Post IDs separated by a %s that should bypass the cache.', 'cache-enabler' ), '<code class="code--form-control">,</code>' );
-                                    ?>
+                                        <?php
+                                        // translators: %s: ,
+                                        printf(
+                                            esc_html__( 'Post IDs separated by a %s that should bypass the cache.', 'cache-enabler' ),
+                                            '<code class="code--form-control">,</code>'
+                                        );
+                                        ?>
                                     </p>
                                     <p><?php esc_html_e( 'Example:', 'cache-enabler' ); ?> <code class="code--form-control">2,43,65</code></p>
                                 </label>
@@ -1815,8 +1810,8 @@ final class Cache_Enabler {
                                 <br />
 
                                 <p class="subheading"><?php esc_html_e( 'Page Paths', 'cache-enabler' ); ?></p>
-                                <label for="excluded_page_paths">
-                                    <input name="cache_enabler[excluded_page_paths]" type="text" id="excluded_page_paths" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_page_paths'] ) ?>" class="regular-text code" />
+                                <label for="cache_enabler_excluded_page_paths">
+                                    <input name="cache_enabler[excluded_page_paths]" type="text" id="cache_enabler_excluded_page_paths" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_page_paths'] ) ?>" class="regular-text code" />
                                     <p class="description"><?php esc_html_e( 'A regex matching page paths that should bypass the cache.', 'cache-enabler' ); ?></p>
                                     <p><?php esc_html_e( 'Example:', 'cache-enabler' ); ?> <code class="code--form-control">/^(\/|\/forums\/)$/</code></p>
                                 </label>
@@ -1824,8 +1819,8 @@ final class Cache_Enabler {
                                 <br />
 
                                 <p class="subheading"><?php esc_html_e( 'Query Strings', 'cache-enabler' ); ?></p>
-                                <label for="excluded_query_strings">
-                                    <input name="cache_enabler[excluded_query_strings]" type="text" id="excluded_query_strings" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_query_strings'] ) ?>" class="regular-text code" />
+                                <label for="cache_enabler_excluded_query_strings">
+                                    <input name="cache_enabler[excluded_query_strings]" type="text" id="cache_enabler_excluded_query_strings" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_query_strings'] ) ?>" class="regular-text code" />
                                     <p class="description"><?php esc_html_e( 'A regex matching query strings that should bypass the cache.', 'cache-enabler' ); ?></p>
                                     <p><?php esc_html_e( 'Example:', 'cache-enabler' ); ?> <code class="code--form-control">/^nocache$/</code></p>
                                     <p><?php esc_html_e( 'Default if unset:', 'cache-enabler' ); ?> <code class="code--form-control">/^(?!(fbclid|ref|mc_(cid|eid)|utm_(source|medium|campaign|term|content|expid)|gclid|fb_(action_ids|action_types|source)|age-verified|usqp|cn-reloaded|_ga|_ke)).+$/</code></p>
@@ -1834,8 +1829,8 @@ final class Cache_Enabler {
                                 <br />
 
                                 <p class="subheading"><?php esc_html_e( 'Cookies', 'cache-enabler' ); ?></p>
-                                <label for="excluded_cookies">
-                                    <input name="cache_enabler[excluded_cookies]" type="text" id="excluded_cookies" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_cookies'] ) ?>" class="regular-text code" />
+                                <label for="cache_enabler_excluded_cookies">
+                                    <input name="cache_enabler[excluded_cookies]" type="text" id="cache_enabler_excluded_cookies" value="<?php echo esc_attr( Cache_Enabler_Engine::$settings['excluded_cookies'] ) ?>" class="regular-text code" />
                                     <p class="description"><?php esc_html_e( 'A regex matching cookies that should bypass the cache.', 'cache-enabler' ); ?></p>
                                     <p><?php esc_html_e( 'Example:', 'cache-enabler' ); ?> <code class="code--form-control">/^(comment_author|woocommerce_items_in_cart|wp_woocommerce_session)_?/</code></p>
                                     <p><?php esc_html_e( 'Default if unset:', 'cache-enabler' ); ?> <code class="code--form-control">/^(wp-postpass|wordpress_logged_in|comment_author)_/</code></p>
@@ -1846,8 +1841,8 @@ final class Cache_Enabler {
                 </table>
 
                 <p class="submit">
-                <input type="submit" class="button-secondary" value="<?php esc_html_e( 'Save Changes', 'cache-enabler' ); ?>" />
-                <input name="cache_enabler[clear_site_cache_on_saved_settings]" type="submit" class="button-primary" value="<?php esc_html_e( 'Save Changes and Clear Site Cache', 'cache-enabler' ); ?>" />
+                    <input type="submit" class="button-secondary" value="<?php esc_html_e( 'Save Changes', 'cache-enabler' ); ?>" />
+                    <input name="cache_enabler[clear_site_cache_on_saved_settings]" type="submit" class="button-primary" value="<?php esc_html_e( 'Save Changes and Clear Site Cache', 'cache-enabler' ); ?>" />
                 </p>
             </form>
         </div>

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -29,6 +29,7 @@ final class Cache_Enabler_Engine {
         return self::$started;
     }
 
+
     /**
      * engine status
      *

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ A lightweight caching plugin for WordPress that makes your website faster by gen
 
 
 == Description ==
-Cache Enabler is a simple, yet powerful WordPress caching plugin that is easy to use, needs minimal configuration, and best of all helps improve site performance for a faster load time. It creates static HTML files and stores them on the server's disk. This allows the web server to deliver the static HTML files avoiding resource intensive backend processes from the WordPress core, plugins, and database lookups.
+Cache Enabler is a simple, yet powerful WordPress caching plugin that is easy to use, needs minimal configuration, and best of all helps improve site performance for a faster load time. It creates static HTML files and stores them on the server's disk. This allows the web server to deliver the static HTML files avoiding resource intensive backend processes from the WordPress core, plugins, and database.
 
 
 = Features =
@@ -25,15 +25,15 @@ Cache Enabler is a simple, yet powerful WordPress caching plugin that is easy to
 * Cache size display in the WordPress dashboard
 * Minification of HTML excluding or including inline CSS and JavaScript
 * WordPress multisite network support
-* WebP support (convert images to WebP with [Optimus](https://optimus.io "Optimus"))
+* WebP support (convert images to WebP with [Optimus](https://optimus.io))
 * Gzip pre-compression support
 * Custom post type support
 * `304 Not Modified` support
-* Works perfectly with [Autoptimize](https://wordpress.org/plugins/autoptimize/) and the majority of third party plugins
+* Works perfectly with [Autoptimize](https://wordpress.org/plugins/autoptimize/) and the majority of other third party plugins
 
 
 = How does the caching work? =
-Cache Enabler captures page contents and saves it as a static HTML file on the server’s disk. Converting inline image URLs to WebP as a separate static HTML file and pre-compressing both static HTML files with Gzip is possible. The accepted static HTML file is then delivered to users without any database lookups or on the fly compression for a faster site load time.
+Cache Enabler captures page contents and saves it as a static HTML file on the server’s disk. Converting inline image URLs to WebP as a separate static HTML file and pre-compressing both static HTML files with Gzip is possible. The accepted static HTML file is then delivered to users without any database queries or on the fly compression for a faster site load time.
 
 
 = Documentation =
@@ -46,7 +46,7 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 
 = Want to help? =
-* Want to file a bug, contribute some code, or improve translations? Excellent! Check out our [GitHub issues](https://github.com/keycdn/cache-enabler) or [translations](https://translate.wordpress.org/projects/wp-plugins/cache-enabler/).
+* Want to file a bug, contribute some code, or improve translations? Excellent! Check out our [GitHub issues](https://github.com/keycdn/cache-enabler/issues) or [translations](https://translate.wordpress.org/projects/wp-plugins/cache-enabler/).
 
 
 = Maintainer =


### PR DESCRIPTION
Clean code base with changes primarily coming from recent refactor of CDN Enabler, such as:

* Validate settings when backend is being updated.

* Fix how the settings version is checked when getting the settings from the database.

* Update order of settings to reflect the order displayed in the settings page.

* Prepend settings link instead of appending it in the plugin row.

* Use `printf()` instead of `echo sprintf()`.

* Update element IDs to use `cache_enabler_*` prefix to avoid potential (highly unlikely) collisions.