### PR TITLE
update getting image path

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -913,7 +913,7 @@ final class Cache_Enabler_Disk {
 
         // in case installation is in a subdirectory
         $image_url_path = ltrim( parse_url( $image_url, PHP_URL_PATH ), '/' );
-        $installation_dir = preg_replace( '/^[^\/]+\/\K.+/', '', $image_url_path );
+        $installation_dir = ltrim( parse_url( site_url( '/' ), PHP_URL_PATH ), '/' );
         $image_path = str_replace( $installation_dir, '', ABSPATH ) . $image_url_path;
 
         return $image_path;


### PR DESCRIPTION
Update getting the installation directory in `Cache_Enabler_Disk::get_image_path()`. Previously, only the first subdirectory would be retrieved from the image URL path and that would be removed from the `ABSPATH` value, which means converting inline image URLs to WebP would not be successful if an installation was installed in a subdirectory two levels deep or greater. (This does not appear to be common as no issues that I am aware of have been opened, but came across this case in one of my own installations.) This new way will take the URL path from the [`site_url()`](https://developer.wordpress.org/reference/functions/site_url/) value, which comes from the WordPress Address (URL) setting, and remove it from the value retrieved from the `ABSPATH` constant.

This also will prevent another edge case that could have previously occurred where an incorrect image path would be returned by this method if the first directory in the image URL path was in the `ABSPATH` value but was not an installation directory. This would cause the image URLs to not be rewritten as the incorrect image path would result in the image not being found. For example, if the `ABSPATH` value was `path/to/public` and `https://www.example.com/public/image.jpg` was requested, the image path that would be returned would be `path/to/public/image.jpg`, but it should be `path/to/public/public/image.jpg` instead. (This was also an issue that I have not seen opened yet, but came across in a series of tests.)