### PR TITLE
update getting filesystem

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -941,7 +941,7 @@ final class Cache_Enabler_Disk {
 
         // try initializing filesystem instance and cache the result
         try {
-            require_once ABSPATH . '/wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/file.php';
 
             $filesystem = WP_Filesystem();
 


### PR DESCRIPTION
Update the `require_once` statement in the `Cache_Enabler_Disk::get_filesystem()` method that was added in PR #194 to not include a leading forward slash because the `ABSPATH` constant has a trailing forward slash.