### PR TITLE
update HTML minification

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1106,7 +1106,7 @@ final class Cache_Enabler_Disk {
      * minify HTML
      *
      * @since   1.0.0
-     * @change  1.6.2
+     * @change  1.7.0
      *
      * @param   string  $page_contents                 contents of a page from the output buffer
      * @return  string  $page_contents|$minified_html  minified page contents if applicable, unchanged otherwise
@@ -1149,7 +1149,7 @@ final class Cache_Enabler_Disk {
         // if setting selected remove CSS and JavaScript comments
         if ( Cache_Enabler_Engine::$settings['minify_inline_css_js'] ) {
             $minified_html = preg_replace(
-                '#/\*[\s\S]*?\*/|([^\'\"\\:\w]|^)//.*$#m',
+                '#/\*(?!!)[\s\S]*?\*/|(?:^[ \t]*)//.*$|((?<!\()[ \t>;,{}[\]])//[^;\n]*$#m',
                 '$1',
                 $minified_html
             );


### PR DESCRIPTION
Update what was added in PR #184 and then updated in PR #188 for removing inline CSS and JavaScript comments:

* Add support for not removing ignored comments (e.g. `/*! ignored comment */`).

* Update single line comment handling (e.g. `// comment`):

    * Only remove single line comments when they come after a character explicitly allowed instead of any character other than what was explicitly disallowed. This will fix the edge cases where some data URIs or protocol-relative URLs were matched as a comment. This may need to be expanded upon if more characters are found where this type of comment comes after.

    * Do not remove single line comment if it contains a `;` and did not start at the beginning of a line with or without preceding space(s) and/or tab(s). This will help prevent false matches.

Regex tests:

* Old pattern: https://regex101.com/r/iIt1Ng/1

* New pattern: https://regex101.com/r/qSKTGx/1