### PR TITLE
update settings file deletion handling

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1208,7 +1208,7 @@ final class Cache_Enabler_Disk {
      * delete settings file
      *
      * @since   1.5.0
-     * @change  1.5.0
+     * @change  1.7.0
      */
 
     private static function delete_settings_file() {
@@ -1221,6 +1221,9 @@ final class Cache_Enabler_Disk {
 
         // delete settings directory if empty
         @rmdir( self::$settings_dir );
+
+        // delete parent directory of settings directory if empty
+        @rmdir( dirname( self::$settings_dir ) );
     }
 
 


### PR DESCRIPTION
Update settings file deletion handling to also delete the parent directory of the settings directory if empty. Previously only `wp-content/settings/cache-enabler` would be deleted if empty. This means if `wp-content/settings` is empty it will now also be deleted. This will prevent leaving an empty directory that was created by Cache Enabler if the plugin is deactivated.