### PR TITLE
update cache handling

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -516,10 +516,10 @@ final class Cache_Enabler {
 
 
     /**
-     * get cache size
+     * get cache size from database or disk
      *
      * @since   1.0.0
-     * @change  1.5.0
+     * @change  1.7.0
      *
      * @return  integer  $cache_size  cache size in bytes
      */
@@ -529,7 +529,7 @@ final class Cache_Enabler {
         $cache_size = get_transient( self::get_cache_size_transient_name() );
 
         if ( ! $cache_size ) {
-            $cache_size = Cache_Enabler_Disk::cache_size();
+            $cache_size = Cache_Enabler_Disk::get_cache_size();
             set_transient( self::get_cache_size_transient_name(), $cache_size, MINUTE_IN_SECONDS * 15 );
         }
 
@@ -599,6 +599,7 @@ final class Cache_Enabler {
             'clear_site_cache_on_saved_comment'  => 0,
             'clear_site_cache_on_changed_plugin' => 0,
             'convert_image_urls_to_webp'         => 0,
+            'mobile_cache'                       => 0,
             'compress_cache'                     => 0,
             'minify_html'                        => 0,
             'minify_inline_css_js'               => 0,
@@ -1628,6 +1629,7 @@ final class Cache_Enabler {
             'clear_site_cache_on_saved_comment'  => (int) ( ! empty( $settings['clear_site_cache_on_saved_comment'] ) ),
             'clear_site_cache_on_changed_plugin' => (int) ( ! empty( $settings['clear_site_cache_on_changed_plugin'] ) ),
             'convert_image_urls_to_webp'         => (int) ( ! empty( $settings['convert_image_urls_to_webp'] ) ),
+            'mobile_cache'                       => (int) ( ! empty( $settings['mobile_cache'] ) ),
             'compress_cache'                     => (int) ( ! empty( $settings['compress_cache'] ) ),
             'minify_html'                        => (int) ( ! empty( $settings['minify_html'] ) ),
             'minify_inline_css_js'               => (int) ( ! empty( $settings['minify_inline_css_js'] ) ),
@@ -1749,6 +1751,13 @@ final class Cache_Enabler {
                                         '<a href="https://optimus.io" target="_blank" rel="nofollow noopener">Optimus</a>'
                                     );
                                     ?>
+                                </label>
+
+                                <br />
+
+                                <label for="cache_enabler_mobile_cache">
+                                    <input name="cache_enabler[mobile_cache]" type="checkbox" id="cache_enabler_mobile_cache" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['mobile_cache'] ); ?> />
+                                    <?php esc_html_e( 'Create an additional cached version for mobile devices.', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />


### PR DESCRIPTION
Update cache handling to get the cache file based on the request, mostly looking at the Cache Enabler settings and request headers. This updates the cache handling for both new and potentially cached pages by generating the required cache file through cache keys. This will be much better going forward as it simplifies handling current cache variants and adding additional cache variants in the future. The previous way of handling this would mean many methods and convoluted logic would have to be added on each additional cache variant. As each variant is added that would have only lead to more unnecessary complexity.

The cache keys are obtained in the following ways:

* `scheme`: Scheme-based caching was introduced in PR #94 and released in version 1.4.0. This was then later updated in PR #98, PR #109, and PR #141. Change this to use what the WordPress [`is_ssl()`](https://developer.wordpress.org/reference/functions/is_ssl/) function uses with the added ability to also check the `X-Forwarded-Proto` or `X-Forwarded-Scheme` request headers.

* `device`: Device-based caching will be introduced in this PR and released in version 1.7.0. This will allow a separate mobile cache to be made based on the `User-Agent` request header. The values checked have been taken from the WordPress [`wp_is_mobile()`](https://developer.wordpress.org/reference/functions/wp_is_mobile/) function (#160).

* `webp`: WebP-based caching was released in version 1.0.2. This still checks the `Accept` request header, but will now look for `image/webp` instead of just `webp`.

* `compression`: Compression-based caching for Gzip has been supported since the initial release. This still checks the `Accept-Encoding` request header for `gzip`. This setup will make it easy for other compression algorithms to be introduced in the future.

This change means that only the requested cache file is created if it does not exist yet instead of all variants at once. This will reduce unnecessary memory usage, especially if many cache variants are used, and will reduce storing unnecessary cache variants that may never even be requested. (This will impact anyone using cache warming techniques because a request for each variant to cache will now have to be made.) This also ensures the client gets what it has requested instead of falling back to the default HTML file if the requested variant does not exist yet but the default HTML file did. (That was pretty rare edge case as it would only previously occur if a cache variant setting was enabled after cached pages were already generated and the cache was not cleared.)

Getting the request headers has been updated as in some cases [`apache_request_headers()`](https://www.php.net/manual/en/function.apache-request-headers.php) was a function that existed but returned an empty array or `false`. This lead to some cache variants not being delivered even when accepted by the client. This new way will try to get the request header from `apache_request_headers()` and if not set then fallback to the [`$_SERVER`](https://www.php.net/manual/en/reserved.variables.server.php) variable. If neither are set then an empty string to prevent having to always check if it is set. Only checking `$_SERVER` variables was not used as some environments do not provide all of these. This way should get the specific request header values we need across many different configurations if it is available.

The cache signature will now include the file name, such as `https-index-webp.html.gz`, instead of `https webp gzip` because of this new handling. We can filter this and update it to the old format if preferred. (I do not have a preference, this way just reduces the overhead.) The cache signature will now also include the generated date in HTTP-date format (e.g. `D, d M Y H:i:s GMT`) instead of `d.m.Y H:i:s`.

Update `Cache_Enabler_Disk::get_settings_file_name()` to parse the `$_SERVER['REQUEST_URI']` value and get the `PHP_URL_PATH` when in the subdirectory network fallback to prevent a warning from occurring in the following `preg_grep()` function when the path contained a query string. The `?` from the query string would cause a regular expression error if the path had a trailing slash (preceding token is not quantifiable, like in `\.(path|to|page|?param=value)`).

For a future note, error handling when creating directories and compressing page contents needs to be improved. `wp_die()` for failed cache file directory creation has been removed as it did not work and would have caused an output buffer error instead. As far as I can tell this would have always occurred in all past versions. This would not occur when trying to create the settings file, but it has been removed for this as well as it is not a graceful way to handle this type of error. If Gzip compression failed the page will not be created. These all rarely occur, if they ever do as no issues have been opened around these scenarios, but in the event they do the user should receive additional insight to what is occurring so it can be resolved.

Closes #160