### PR TITLE
fix clear cache request handling

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -889,7 +889,7 @@ final class Cache_Enabler {
      * process clear cache request
      *
      * @since   1.0.0
-     * @change  1.6.0
+     * @change  1.7.0
      */
 
     public static function process_clear_cache_request() {
@@ -911,8 +911,7 @@ final class Cache_Enabler {
 
         // clear page cache
         if ( $_GET['_action'] === 'clearurl' ) {
-            // set clear URL without query string
-            $clear_url = parse_url( home_url(), PHP_URL_SCHEME ) . '://' . parse_url( home_url(), PHP_URL_HOST ) . preg_replace( '/\?.*/', '', $_SERVER['REQUEST_URI'] );
+            $clear_url = parse_url( home_url(), PHP_URL_SCHEME ) . '://' . Cache_Enabler_Engine::$request_headers['Host'] . $_SERVER['REQUEST_URI'];
             self::clear_page_cache_by_url( $clear_url );
         // clear site(s) cache
         } elseif ( $_GET['_action'] === 'clear' ) {
@@ -920,7 +919,7 @@ final class Cache_Enabler {
         }
 
         // redirect to same page
-        wp_safe_redirect( wp_get_referer() );
+        wp_safe_redirect( remove_query_arg( array( '_cache', '_action', '_wpnonce' ) ) );
 
         // set transient for clear notice
         if ( is_admin() ) {


### PR DESCRIPTION
Fix clear cache request handling to redirect to the current URL path with the query parameters `_cache`, `_action`, `_wpnonce` removed instead of [`wp_get_referer()`](https://developer.wordpress.org/reference/functions/wp_get_referer/). Previously, if the `Referer` request header was not sent, like if `Referrer-Policy: no-referrer` response header was set, this would cause the redirect to be cancelled and then script to be terminated. This lead to the response body being empty.

The clear URL can have query strings so `$_SERVER['REQUEST_URI']` does not need to be filtered here as the path will be pulled from it in `Cache_Enabler_Disk::get_cache_file_dir()`. I think this was originally done due to the old, deprecated `ce_action_cache_by_url_cleared` action hook that used to be fired before the cache was cleared.

WordPress topic: https://wordpress.org/support/topic/blank-page-if-referrer-policy-directive-is-set/