### PR TITLE
Added cache_enabler_no_bypass_response filter

### DIFF
--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -384,10 +384,10 @@ final class Cache_Enabler_Engine {
             return true;
         }
 
-        // check HTTP status code
-        if ( http_response_code() !== 200 ) {
-            return true;
-        }
+		// check HTTP status code filter to prevent bypass
+		if ( !in_array( http_response_code(), apply_filters( 'cache_enabler_no_bypass_response', $response ) ) && http_response_code() !== 200 ) {
+        	return true;
+		}
 
         // check DONOTCACHEPAGE constant
         if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {


### PR DESCRIPTION
With cache_enabler_no_bypass_response filter, we can choose NOT to bypass the cache for different response codes provided by the user in an array.

Example use of cache_enabler_no_bypass_response filter to bypass 404 pages:

```
add_filter( 'cache_enabler_no_bypass_response', 'ce_no_bypass_response' );
function ce_no_bypass_response( $response ) {
	$response = array(404);
	return $response;
}
```

This was created to address issue #213.