### PR TITLE
update cache clearing

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -62,7 +62,7 @@ spl_autoload_register( 'cache_enabler_autoload' );
 // load required classes
 function cache_enabler_autoload( $class_name ) {
     // check if classes were loaded in advanced-cache.php
-    if ( in_array( $class_name, array( 'Cache_Enabler', 'Cache_Enabler_Engine', 'Cache_Enabler_Disk' ) ) && ! class_exists( $class_name ) ) {
+    if ( in_array( $class_name, array( 'Cache_Enabler', 'Cache_Enabler_Engine', 'Cache_Enabler_Disk' ), true ) && ! class_exists( $class_name ) ) {
         require_once sprintf(
             '%s/inc/%s.class.php',
             CACHE_ENABLER_DIR,

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -770,7 +770,7 @@ final class Cache_Enabler_Disk {
      * get site file system objects
      *
      * @since   1.6.0
-     * @change  1.6.0
+     * @change  1.7.0
      *
      * @param   string  $site_url      site URL
      * @return  array   $site_objects  site objects
@@ -797,10 +797,10 @@ final class Cache_Enabler_Disk {
             $blog_paths = Cache_Enabler::get_blog_paths();
 
             // check if main site in subdirectory network
-            if ( ! in_array( $blog_path, $blog_paths ) ) {
+            if ( ! in_array( $blog_path, $blog_paths, true ) ) {
                 foreach ( $site_objects as $key => $site_object ) {
                     // delete site object if it does not belong to main site
-                    if ( in_array( '/' . $site_object . '/', $blog_paths ) ) {
+                    if ( in_array( '/' . $site_object . '/', $blog_paths, true ) ) {
                         unset( $site_objects[ $key ] );
                     }
                 }

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -280,7 +280,7 @@ final class Cache_Enabler_Engine {
      * check if page is excluded from cache
      *
      * @since   1.5.0
-     * @change  1.5.3
+     * @change  1.7.0
      *
      * @return  boolean  true if page is excluded from the cache, false otherwise
      */
@@ -289,7 +289,10 @@ final class Cache_Enabler_Engine {
 
         // if post ID excluded
         if ( ! empty( self::$settings['excluded_post_ids'] ) && function_exists( 'is_singular' ) && is_singular() ) {
-            if ( in_array( get_queried_object_id(), (array) explode( ',', self::$settings['excluded_post_ids'] ) ) ) {
+            $post_id = get_queried_object_id();
+            $excluded_post_ids = array_map( 'absint', (array) explode( ',', self::$settings['excluded_post_ids'] ) );
+
+            if ( in_array( $post_id, $excluded_post_ids, true ) ) {
                 return true;
             }
         }


### PR DESCRIPTION
Add cache clearing behavior for when one or more themes are updated. This new behavior will now automatically clear the site cache if the active or parent theme has been updated.

Update cache clearing behavior for when one or more plugins are updated. This will now only take place when the update process is actually `plugin` as it was intended. This would have previously cleared the site cache whenever the [`upgrader_process_complete`](https://developer.wordpress.org/reference/hooks/upgrader_process_complete/) action hook was fired and the associated setting was enabled, regardless of the type of update process (e.g. `plugin`, `theme`, `translation`, or `core`). Update that associated setting to now only clear the site cache when a plugin is activated or deactivated as Cache Enabler will now automatically handle cache clearing when a plugin has been updated.

Update cache clearing for theme switching to clear the site cache instead of the complete cache. This change makes it so when a theme is switched in a multisite network only that site cache is cleared instead of the entire network since this is done on a site level and not network level. This has no effect on single site installations.

Update instances of [`in_array()`](https://www.php.net/manual/en/function.in-array.php) to use strict checks to prevent odd results in some cases. Further, our standard has been to use strict comparisons unless a loose comparison is required.