### PR TITLE
Fix references to $wp_filesystem->errors

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -885,8 +885,8 @@ final class Cache_Enabler_Disk {
             if ( $filesystem === false ) {
                 if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
                     throw new \RuntimeException(
-                        $wp_filesystem->get_error_message,
-                        ( is_numeric( $wp_error->get_error_code() ) ) ? (int) $wp_error->get_error_code() : 0
+                        $wp_filesystem->errors->get_error_message(),
+                        ( is_numeric( $wp_filesystem->errors->get_error_code() ) ) ? (int) $wp_filesystem->errors->get_error_code() : 0
                     );
                 }
 


### PR DESCRIPTION
[As noted by @coreykn on the original PR](https://github.com/keycdn/cache-enabler/pull/194#issuecomment-804367079), the error handling for WP filesystem errors was previously a) treating `$wp_filesystem` as a `WP_Error` object instead of `$wp_filesystem->errors` and b) referencing a non-existent `$wp_error` variable.

This PR updates the error handling to consistently use `$wp_filesystem->errors`, causing a `RuntimeException` to be be thrown for [first, if multiple errors are present] error within the `$wp->filesystem->errors` object.