### PR TITLE
add new cache clearing structure for term actions

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1322,7 +1322,7 @@ final class Cache_Enabler {
     public static function clear_taxonomies_archives_cache_by_post_id( $post_id ) {
 
         // get public taxonomies
-        $taxonomies = array_filter( get_taxonomies(),  array( __CLASS__, 'is_taxonomy_public' ) );
+        $taxonomies = array_filter( get_taxonomies(),  'is_taxonomy_viewable' );
 
         // get terms attached to post
         $terms = wp_get_post_terms( $post_id, $taxonomies );
@@ -1475,7 +1475,7 @@ final class Cache_Enabler {
     public static function on_saved_delete_term( $term_id, $tt_id, $taxonomy ) {
 
         // only clear cache if taxonomy is public
-        if ( self::is_taxonomy_public( $taxonomy ) ) {
+        if ( is_taxonomy_viewable( $taxonomy ) ) {
 
             // if setting enabled clear site cache
             if ( Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_term'] ) {
@@ -1489,21 +1489,6 @@ final class Cache_Enabler {
                 }
             }
         }
-    }
-
-
-    /**
-     * check if taxonomy is public
-     *
-     * @since   1.8.0
-     * @change  1.8.0
-     *
-     * @param   string  $taxonomy  taxonomy slug
-     */
-
-    public static function is_taxonomy_public( $taxonomy ) {
-        $wp_taxonomy = get_taxonomy( $taxonomy );
-        return ( $wp_taxonomy && $wp_taxonomy->public );
     }
 
 

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1194,7 +1194,7 @@ final class Cache_Enabler {
      * @change  1.8.0
      *
      * @param   integer  $term_id   term ID
-     * @param   string   $taxonomy  taxonomy name that $term is part of
+     * @param   string   $taxonomy  taxonomy name that $term_id is part of
      */
 
     public static function on_edit_terms( $term_id, $taxonomy ) {
@@ -1215,7 +1215,7 @@ final class Cache_Enabler {
      *
      * @param   integer  $term_id   term ID
      * @param   integer  $tt_id     term taxonomy ID
-     * @param   string   $taxonomy  taxonomy name that $term is part of
+     * @param   string   $taxonomy  taxonomy name that $term_id is part of
      */
 
     public static function on_saved_delete_term( $term_id, $tt_id, $taxonomy ) {
@@ -2083,7 +2083,7 @@ final class Cache_Enabler {
 
                                 <label for="cache_enabler_clear_site_cache_on_saved_term">
                                     <input name="cache_enabler[clear_site_cache_on_saved_term]" type="checkbox" id="cache_enabler_clear_site_cache_on_saved_term" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_term'] ); ?> />
-                                    <?php esc_html_e( 'Clear the site cache if a tag, category, or custom taxonomy has been added, updated, or deleted (instead of only the page and/or associated cache).', 'cache-enabler' ); ?>
+                                    <?php esc_html_e( 'Clear the site cache if a category, tag, or custom taxonomy term has been added, updated, or deleted (instead of only the archive and/or associated cache).', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1353,8 +1353,8 @@ final class Cache_Enabler {
 
     public static function clear_term_archive_cache( $term, $taxonomy = '' ) {
 
-        $term = self::get_term( $term, $taxonomy );
-        if ( $term ) {
+        $term = get_term( $term, $taxonomy );
+        if ( $term instanceOf WP_Term ) {
             $term_archive_url = get_term_link( $term );
 
             // if term archives URL exists and does not have a query string, clear taxonomy archives page and its pagination page(s) cache
@@ -1482,8 +1482,8 @@ final class Cache_Enabler {
                 self::clear_site_cache();
                 // clear term archive and/or associated cache otherwise
             } else {
-                $term = self::get_term( $term_id, $taxonomy );
-                if ( $term ) {
+                $term = get_term( $term_id, $taxonomy );
+                if ( $term instanceOf WP_Term ) {
                     self::clear_term_archive_cache( $term );
                     self::clear_cache_associated_with_term( $term );
                 }
@@ -1508,28 +1508,6 @@ final class Cache_Enabler {
 
 
     /**
-     * convert term_id and taxonomy to WP_Term instance
-     *
-     * @since   1.8.0
-     * @change  1.8.0
-     *
-     * @param   WP_Term|int  $term      term instance or term_id
-     * @param   string       $taxonomy  (optional) taxonomy slug
-     */
-
-    public static function get_term( $term, $taxonomy = '' ) {
-
-        if ( ! is_object( $term ) ) {
-            $term = get_term( $term, $taxonomy );
-            if ( ! $term || is_wp_error( $term ) ) {
-                return false;
-            }
-        }
-        return $term;
-    }
-
-
-    /**
      * clear all cached pages that are associated with term
      *
      * @since   1.8.0
@@ -1541,8 +1519,8 @@ final class Cache_Enabler {
 
     public static function clear_cache_associated_with_term( $term, $taxonomy = '' ) {
 
-        $term = self::get_term( $term, $taxonomy );
-        if ( $term ) {
+        $term = get_term( $term, $taxonomy );
+        if ( $term instanceOf WP_Term ) {
 
             if ( is_taxonomy_hierarchical( $term->taxonomy ) ) {
                 // clear child term cache (term could be part of a breadcrumb list on child pages)
@@ -1570,8 +1548,8 @@ final class Cache_Enabler {
 
     public static function clear_child_term_cache( $term, $taxonomy = '' ) {
 
-        $term = self::get_term( $term, $taxonomy );
-        if ( $term ) {
+        $term = get_term( $term, $taxonomy );
+        if ( $term instanceOf WP_Term ) {
             $child_ids = get_term_children( $term->term_id, $term->taxonomy );
 
             if ( $child_ids && !is_wp_error( $child_ids ) ) {
@@ -1595,8 +1573,8 @@ final class Cache_Enabler {
 
     public static function clear_parent_term_cache( $term, $taxonomy = '' ) {
 
-        $term = self::get_term( $term, $taxonomy );
-        if ( $term ) {
+        $term = get_term( $term, $taxonomy );
+        if ( $term instanceOf WP_Term ) {
             $parent_ids = get_ancestors( $term->term_id, $term->taxonomy, 'taxonomy' );
 
             foreach ( $parent_ids as $parent_id ) {
@@ -1618,8 +1596,8 @@ final class Cache_Enabler {
 
     public static function clear_page_cache_by_term( $term, $taxonomy = '' ) {
 
-        $term = self::get_term( $term, $taxonomy );
-        if ( $term ) {
+        $term = get_term( $term, $taxonomy );
+        if ( $term instanceOf WP_Term ) {
 
             // clear post pages that are associated with term
             $args = array(

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1354,7 +1354,7 @@ final class Cache_Enabler {
     public static function clear_term_archive_cache( $term, $taxonomy = '' ) {
 
         $term = get_term( $term, $taxonomy );
-        if ( $term instanceOf WP_Term ) {
+        if ( $term instanceof WP_Term ) {
             $term_archive_url = get_term_link( $term );
 
             // if term archives URL exists and does not have a query string, clear taxonomy archives page and its pagination page(s) cache
@@ -1483,7 +1483,7 @@ final class Cache_Enabler {
                 // clear term archive and/or associated cache otherwise
             } else {
                 $term = get_term( $term_id, $taxonomy );
-                if ( $term instanceOf WP_Term ) {
+                if ( $term instanceof WP_Term ) {
                     self::clear_term_archive_cache( $term );
                     self::clear_cache_associated_with_term( $term );
                 }
@@ -1520,7 +1520,7 @@ final class Cache_Enabler {
     public static function clear_cache_associated_with_term( $term, $taxonomy = '' ) {
 
         $term = get_term( $term, $taxonomy );
-        if ( $term instanceOf WP_Term ) {
+        if ( $term instanceof WP_Term ) {
 
             if ( is_taxonomy_hierarchical( $term->taxonomy ) ) {
                 // clear child term cache (term could be part of a breadcrumb list on child pages)
@@ -1549,7 +1549,7 @@ final class Cache_Enabler {
     public static function clear_child_term_cache( $term, $taxonomy = '' ) {
 
         $term = get_term( $term, $taxonomy );
-        if ( $term instanceOf WP_Term ) {
+        if ( $term instanceof WP_Term ) {
             $child_ids = get_term_children( $term->term_id, $term->taxonomy );
 
             if ( $child_ids && !is_wp_error( $child_ids ) ) {
@@ -1574,7 +1574,7 @@ final class Cache_Enabler {
     public static function clear_parent_term_cache( $term, $taxonomy = '' ) {
 
         $term = get_term( $term, $taxonomy );
-        if ( $term instanceOf WP_Term ) {
+        if ( $term instanceof WP_Term ) {
             $parent_ids = get_ancestors( $term->term_id, $term->taxonomy, 'taxonomy' );
 
             foreach ( $parent_ids as $parent_id ) {
@@ -1597,7 +1597,7 @@ final class Cache_Enabler {
     public static function clear_page_cache_by_term( $term, $taxonomy = '' ) {
 
         $term = get_term( $term, $taxonomy );
-        if ( $term instanceOf WP_Term ) {
+        if ( $term instanceof WP_Term ) {
 
             // clear post pages that are associated with term
             $args = array(

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -72,9 +72,9 @@ final class Cache_Enabler {
         add_action( 'comment_post', array( __CLASS__, 'on_comment_post' ), 99, 2 );
         add_action( 'edit_comment', array( __CLASS__, 'on_edit_comment' ), 10, 2 );
         add_action( 'transition_comment_status', array( __CLASS__, 'on_transition_comment_status' ), 10, 3 );
+        add_action( 'saved_term', array( __CLASS__, 'on_saved_delete_term' ), 10, 3 );
         add_action( 'edit_terms', array( __CLASS__, 'on_edit_terms' ), 10, 2 );
-        add_action( 'edit_term', array( __CLASS__, 'on_edit_delete_term' ), 10, 3 );
-        add_action( 'delete_term', array( __CLASS__, 'on_edit_delete_term' ), 10, 3 );
+        add_action( 'delete_term', array( __CLASS__, 'on_saved_delete_term' ), 10, 3 );
 
         // third party clear cache hooks
         add_action( 'autoptimize_action_cachepurged', array( __CLASS__, 'clear_complete_cache' ) );
@@ -1460,7 +1460,7 @@ final class Cache_Enabler {
 
 
     /**
-     * edit or delete term hook
+     * saved or delete term hook
      *
      * runs after the term has been updated in the database
      *
@@ -1472,7 +1472,7 @@ final class Cache_Enabler {
      * @param   string   $taxonomy  taxonomy slug
      */
 
-    public static function on_edit_delete_term( $term_id, $tt_id, $taxonomy ) {
+    public static function on_saved_delete_term( $term_id, $tt_id, $taxonomy ) {
 
         // only clear cache if taxonomy is public
         if ( self::is_taxonomy_public( $taxonomy ) ) {
@@ -2080,7 +2080,7 @@ final class Cache_Enabler {
 
                                 <label for="cache_enabler_clear_site_cache_on_saved_term">
                                     <input name="cache_enabler[clear_site_cache_on_saved_term]" type="checkbox" id="cache_enabler_clear_site_cache_on_saved_term" value="1" <?php checked( '1', Cache_Enabler_Engine::$settings['clear_site_cache_on_saved_term'] ); ?> />
-                                    <?php esc_html_e( 'Clear the site cache if a tag, category, or custom taxonomy term has been updated or deleted (instead of only the associated pages).', 'cache-enabler' ); ?>
+                                    <?php esc_html_e( 'Clear the site cache if a tag, category, or custom taxonomy has been added, updated, or deleted (instead of only the page and/or associated cache).', 'cache-enabler' ); ?>
                                 </label>
 
                                 <br />


### PR DESCRIPTION
This extends #129 to also support term updates. The term archive will be cleared from cache on term updates as well as parent and child archives and pages associated with the updated term. In addition to that, parent term archives will be cleared on post updates, since they often contain posts from child terms. Last but not least, the repeated queries for associated terms in `Cache_Enabler::clear_taxonomies_archives_cache_by_post_id()` were consolidated into a single query and updated to only consider taxonomies.