### PR TITLE
add wildcard cache clearing

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1657,6 +1657,18 @@ final class Cache_Enabler {
             $args['hooks']['include'] = 'cache_enabler_page_cache_cleared';
         }
 
+        $url_path = (string) parse_url( $url, PHP_URL_PATH );
+
+        if ( substr( $url_path, -1 ) === '*' ) {
+            $url_path_pieces  = explode( '/', $url_path );
+            $wildcard_subpage = end( $url_path_pieces );
+            $new_url_path     = substr( $url_path, 0, -strlen( $wildcard_subpage ) );
+            $url              = str_replace( $url_path, $new_url_path, $url );
+
+            $args['subpages']['include'] = $wildcard_subpage;
+            $args['root'] = Cache_Enabler_Disk::$cache_dir . '/' . substr( (string) parse_url( $url, PHP_URL_HOST ) . $url_path, 0, -1 );
+        }
+
         Cache_Enabler_Disk::cache_iterator( $url, $args );
     }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -191,6 +191,10 @@ final class Cache_Enabler_Disk {
 
         foreach ( $cache_objects as $cache_object ) {
             if ( is_file( $cache_object ) ) {
+                if ( $args['root'] && strpos( $cache_object, $args['root'] ) !== 0 ) {
+                    continue; // skip to next object because file does not start with provided root path
+                }
+
                 $cache_object_name = basename( $cache_object );
 
                 if ( $cache_keys_regex && ! preg_match( $cache_keys_regex, $cache_object_name ) ) {
@@ -583,6 +587,7 @@ final class Cache_Enabler_Disk {
             'keys'     => 0,
             'expired'  => 0,
             'hooks'    => 0,
+            'root'     => '',
         );
 
         // merge arguments defined in query string into arguments defined in parameter
@@ -1525,7 +1530,9 @@ final class Cache_Enabler_Disk {
         $validated_args = array();
 
         foreach( $args as $arg_name => $arg_value ) {
-            if ( is_array( $arg_value ) ) {
+            if ( $arg_name === 'root' ) {
+                $validated_args[ $arg_name ] = (string) $arg_value;
+            } elseif ( is_array( $arg_value ) ) {
                 foreach( $arg_value as $filter_type => $filter_value ) {
                     if ( is_string( $filter_value ) ) {
                         $filter_value = ( substr_count( $filter_value, '|' ) > 0 ) ? explode( '|', $filter_value ) : explode( ',', $filter_value );


### PR DESCRIPTION
Add support for clearing the cache by URL with a trailing asterisk (`*`) that will match zero or more characters. This is one of two pull requests that are coming after the support for this was added to the directory object filter in PR #245. (The next PR will be using this new feature to purge the comments pagination.) For example, clearing `https://www.example.com/blog/how-to-*` will now clear the cache for any page that the URL contains `www.example.com/blog/how-to-`. Clearing `https://www.example.com/blog/*` will do the same, but will also clear the page `https://www.example.com/blog/` itself, unlike the previous example. Using a query string to pass arguments is still supported, so `https://www.example.com/blog/how-to-*?expired=1` will still clear all matching pages that are expired. (Using a `subpages` inclusion in the query string would overwrite the wildcard in the URL path because query string parameters take precedence. It could also cause unwanted results due to the `root` argument that will be automatically set. That means using that query parameter when clearing the cache with a wildcard URL is not recommended.)

`root` is a new cache iterator argument being introduced, extending what was added in PR #237. This argument allows the wildcard matching to be successful by defining a root directory path, which can be partial or full, to optionally be set. The purpose of this is to only iterate over cache objects (files and directories) that a part of the given path (likely only when a wildcard path is provided). For example, in the wildcard examples above, the `root` directory path that would automatically be set would be `/path/to/wp-content/cache/cache-enabler/www.example.com/blog/how-to-` and `/path/to/wp-content/cache/cache-enabler/www.example.com/blog/`. In the case of the former path, it would prevent the root cache files from being iterated over (e.g. `/path/to/wp-content/cache/cache-enabler/www.example.com/blog/https-index.html`).

This new argument was required due to how the cache iterator works. A URL is given to it and if a directory matching that URL is found we can iterate through the cache objects. In order to find pages that match `https://www.example.com/blog/how-to-*` we have to query `https://www.example.com/blog/` to search for subpages that match `how-to-*`. While we can choose to include/exclude subpages (directories) and include/exclude cache keys (which is applied to all files), it was not considered that it would need to exclude the given page itself. The `root` argument allows the "starting point" to be extended, allowing the original root path to be overwritten.