### PR TITLE
update cache clearing

### DIFF
--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -66,7 +66,7 @@ class Cache_Enabler_CLI {
 
         // clear page(s) cache by post ID(s) and/or URL(s)
         if ( ! empty( $assoc_args['ids'] ) || ! empty( $assoc_args['urls'] ) ) {
-            array_map( 'Cache_Enabler::clear_page_cache_by_post_id', explode( ',', $assoc_args['ids'] ) );
+            array_map( 'Cache_Enabler::clear_page_cache_by_post', explode( ',', $assoc_args['ids'] ) );
             array_map( 'Cache_Enabler::clear_page_cache_by_url', explode( ',', $assoc_args['urls'] ) );
 
             // check if there is more than one ID and/or URL
@@ -81,7 +81,7 @@ class Cache_Enabler_CLI {
 
         // clear pages cache by blog ID(s)
         if ( ! empty( $assoc_args['sites'] ) ) {
-            array_map( 'Cache_Enabler::clear_site_cache_by_blog_id', explode( ',', $assoc_args['sites'] ) );
+            array_map( 'Cache_Enabler::clear_page_cache_by_site', explode( ',', $assoc_args['sites'] ) );
 
             // check if there is more than one site
             $separators = substr_count( $assoc_args['sites'], ',' );

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -61,10 +61,8 @@ final class Cache_Enabler_Disk {
 
     public static function clean() {
 
-        // delete settings file
         self::delete_settings_file();
 
-        // check if settings directory exists
         if ( ! is_dir( self::$settings_dir ) ) {
             // delete old advanced cache settings file(s) (1.4.0)
             array_map( 'unlink', glob( WP_CONTENT_DIR . '/cache/cache-enabler-advcache-*.json' ) );
@@ -152,8 +150,8 @@ final class Cache_Enabler_Disk {
      * @change  1.8.0
      * @access  private
      *
-     * @param   string  $url    URL (with or without scheme) to potentially cached page
-     * @param   array   $args   arguments for iterating over cache, default is empty (docs coming after finalization and before 1.8.0 release)
+     * @param   string  $url    URL to potentially cached page (with or without scheme)
+     * @param   array   $args   TODO
      * @return  array   $cache  cache data
      */
 
@@ -213,10 +211,9 @@ final class Cache_Enabler_Disk {
                         continue; // skip to next object because file deletion failed
                     }
 
-                    $cache_object_size = ( -1 * $cache_object_size );
+                    $cache_object_size = -$cache_object_size; // cache size is negative when cleared
 
-                    // remove containing directory if empty along with any of its empty parents
-                    self::rmdir( $cache_object_dir, true );
+                    self::rmdir( $cache_object_dir, true ); // remove containing directory if empty along with any of its empty parents
                 }
 
                 if ( strpos( $cache_object_name, 'index' ) === false ) {
@@ -233,8 +230,7 @@ final class Cache_Enabler_Disk {
             }
         }
 
-        // sort cache index so path with least amount of slashes is first
-        uksort( $cache['index'], 'self::sort_dir_objects' );
+        uksort( $cache['index'], 'self::sort_dir_objects' ); // sort cache index so path with least amount of slashes is first
 
         if ( $args['clear'] ) {
             self::fire_cache_cleared_hooks( $cache['index'], $args['hooks'] );
@@ -794,7 +790,7 @@ final class Cache_Enabler_Disk {
 
 
     /**
-     * get cache url from directory path
+     * get cache URL from directory path
      *
      * @since   1.8.0
      * @change  1.8.0
@@ -1508,7 +1504,7 @@ final class Cache_Enabler_Disk {
     public static function delete_asset( $url ) {
 
         if ( empty( $url ) ) {
-            wp_die( 'URL is empty.' );
+            return;
         }
 
         Cache_Enabler::clear_page_cache_by_url( $url, 'subpages' );
@@ -1521,7 +1517,7 @@ final class Cache_Enabler_Disk {
      * @since   1.8.0
      * @change  1.8.0
      *
-     * @param   array  $args            cache iterator arguments (see self::cache_iterator())
+     * @param   array  $args            see self::cache_iterator() for available arguments
      * @return  array  $validated_args  validated cache iterator arguments
      */
 

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -417,7 +417,7 @@ final class Cache_Enabler_Engine {
      * deliver cache
      *
      * @since   1.5.0
-     * @change  1.7.0
+     * @change  1.8.0
      *
      * @return  boolean  false if cached page was not delivered
      */


### PR DESCRIPTION
This PR focuses on updating the cache clearing structure to be built around the WordPress objects that are reflected on frontend pages that Cache Enabler caches (e.g. site, post, comment, term, and user). It is built upon the foundation setup in PR #234 for term actions. This PR adds the cache clearing structure for user actions. This means the cache can now be cleared when a user is added, updated, or deleted. By default Cache Enabler will clear the user cache, which currently is any post that the user the author or has commented on, and the user author archive. If posts are reassigned to a new user upon a user being deleted, the reassigned user cache will also be cleared. If the new setting is enabled the site cache will be cleared instead.

The following methods will clear all of the cache associated with the current global object (if it is set) or of a given object:

* `Cache_Enabler::clear_site_cache( $site = null )` [updated]
* `Cache_Enabler::clear_post_cache( $post = null )` [new]
* `Cache_Enabler::clear_comment_cache( $comment = null )` [new]
* `Cache_Enabler::clear_term_cache( $term, $taxonomy = '' )` [updated, added in PR #234]
* `Cache_Enabler::clear_user_cache( $user = null )` [new]

These methods directly relate with the updated cache clearing settings (two new cache clearing settings will be introduced in version 1.8.0):

<img width="1033" alt="cache-enabler-settings-1-8-0" src="https://user-images.githubusercontent.com/54749229/126263835-71333c01-a35c-4411-b845-138759ff454c.png">

The site, post, comment, term, or user cache in this context is the cache that Cache Enabler considers to be associated with that object. For example, `Cache_Enabler::clear_post_cache( $post )` would first clear the page cache of the post itself. This includes the pagination of that page, which has been updated to also clear the comment pagination (e.g. `/post/comment-page-1/`, `/post/comment-page-2/`, etc.). (Clearing the comment pagination was made possible due to what was added in PR #245. It was originally going to use what followed in PR #246, but it turns out how it was implemented in this PR works a little better and is cleaner. The wildcard cache clearing added in PR #246 will stay because it is useful and may be needed in the future.) Cache Enabler would also include the post type archive, post terms archives, and maybe the post author archive and post date archives. The idea behind this type of clearing is to automatically clear what needs to be when certain actions take place on a website.

Once the methods return handling is improved across the code base we will add hooks to most of the `Cache_Enabler::clear_*_cache()` methods above to allow an easy tap. This will allow custom behavior to easily be added when those methods are called.

This PR improves the standardization and increase the flexibility, like allowing the cache clearing methods to receive the object itself or an ID of the object (integer or numerical string). The following methods will clear the page cache of the posts associated with the given object (and allow the cache iterator arguments to be passed):

* `Cache_Enabler::clear_page_cache_by_site( $site, $args = array() )` [new]
    * Replaces `Cache_Enabler::clear_site_cache_by_blog_id( $blog_id, $args = array() )` [deprecated]
* `Cache_Enabler::clear_page_cache_by_post( $post, $args = array() )` [new]
    * Replaces `Cache_Enabler::clear_page_cache_by_post_id( $post_id, $args = array() )` [deprecated]
* `Cache_Enabler::clear_page_cache_by_comment( $comment, $args = array() )` [new]
* `Cache_Enabler::clear_page_cache_by_term( $term, $args = array() )` [updated, added in PR #234]
* `Cache_Enabler::clear_page_cache_by_user( $user, $args = array() )` [new]
* `Cache_Enabler::clear_page_cache_by_url( $url, $args = array() )` [updated]

PR #234 started an update on the cache clearing structure for post actions that was added in PR #129. This PR added to that with the following methods:

* `Cache_Enabler::clear_post_type_archive_cache()` [new]
    * Replaces `Cache_Enabler::clear_post_type_archives_cache()` [deprecated]
* `Cache_Enabler::clear_post_terms_archives_cache()` [updated]
    * Replaces `Cache_Enabler::clear_taxonomies_archives_cache_by_post_id()` [deprecated]
* `Cache_Enabler::clear_post_author_archive_cache()` [new]
* `Cache_Enabler::clear_post_date_archives_cache()` [new]
    * Replaces `Cache_Enabler::clear_date_archives_cache_by_post_id()` [deprecated]
* `Cache_Enabler::clear_author_archive_cache()` [new]
    * Replaces `Cache_Enabler::clear_author_archives_cache_by_user_id()` [deprecated]

The [`get_post()`](https://developer.wordpress.org/reference/functions/get_post/), [`get_comment()`](https://developer.wordpress.org/reference/functions/get_comment/), [`get_term()`](https://developer.wordpress.org/reference/functions/get_term/), and [`get_userdata()`](https://developer.wordpress.org/reference/functions/get_userdata/)/[`wp_get_current_user()`](https://developer.wordpress.org/reference/functions/wp_get_current_user/) functions are used to get the class instance needed. Many of these functions allow a `null` value to be provided (checked as empty). This directs the function to try and get the current related global value if set. Many of the methods added or updated in this PR allow this due to how those functions work.

Query string checks were added where certain URLs are obtained through a WordPress function. This was done in several methods, including `Cache_Enabler::clear_term_archive_cache()` despite what I said in [my later reply](https://github.com/keycdn/cache-enabler/pull/234#issuecomment-870102851) in PR #234. This decision was made due to the fact that a query string URL can still be returned depending on the permalink structure and other edge cases. The permalink structure does not matter as caching is disabled in that event, however, there are likely other cases that this can occur that I am not aware of. Let us be strict and only send the clear cache request when the URL does not have a query string. What happens if a query string is returned and sent to be cleared? It would clear the wrong page (e.g. `https://example.com?p=99` would clear `https://example.com`).

The `cache_enabler_clear_site_cache_by_blog_id` hooks is being deprecated as the `cache_enabler_clear_site_cache` hook can now be used instead due to the updates made to `Cache_Enabler::clear_site_cache()`.

As always, any feedback is welcome.