### PR TITLE
update permalink structure handling

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -589,15 +589,12 @@ final class Cache_Enabler {
     /**
      * get permalink structure
      *
-     * @since   1.5.0
-     * @change  1.5.0
-     *
-     * @return  string  permalink structure
+     * @since       1.5.0
+     * @deprecated  1.8.0
      */
 
     private static function get_permalink_structure() {
 
-        // get permalink structure
         $permalink_structure = get_option( 'permalink_structure' );
 
         // permalink structure is custom and has a trailing slash
@@ -691,8 +688,9 @@ final class Cache_Enabler {
     private static function get_default_settings( $settings_type = null ) {
 
         $system_default_settings = array(
-            'version'             => (string) CACHE_ENABLER_VERSION,
-            'permalink_structure' => (string) self::get_permalink_structure(),
+            'version'              => (string) CACHE_ENABLER_VERSION,
+            'use_trailing_slashes' => (int) $GLOBALS['wp_rewrite']->use_trailing_slashes,
+            'permalink_structure'  => (string) self::get_permalink_structure(), // deprecated in 1.8.0
         );
 
         if ( $settings_type === 'system' ) {
@@ -1019,7 +1017,7 @@ final class Cache_Enabler {
      * process clear cache request
      *
      * @since   1.5.0
-     * @change  1.7.0
+     * @change  1.8.0
      */
 
     public static function process_clear_cache_request() {
@@ -1041,8 +1039,7 @@ final class Cache_Enabler {
 
         // clear page cache
         if ( $_GET['_action'] === 'clearurl' ) {
-            $clear_url = parse_url( home_url(), PHP_URL_SCHEME ) . '://' . Cache_Enabler_Engine::$request_headers['Host'] . $_SERVER['REQUEST_URI'];
-            self::clear_page_cache_by_url( $clear_url );
+            self::clear_page_cache_by_url( Cache_Enabler_Engine::$request_headers['Host'] . $_SERVER['REQUEST_URI'] );
         // clear site(s) cache
         } elseif ( $_GET['_action'] === 'clear' ) {
             self::each_site( ( is_multisite() && is_network_admin() ), 'self::clear_site_cache' );
@@ -2143,7 +2140,7 @@ final class Cache_Enabler {
         }
 
         // check permalink structure
-        if ( Cache_Enabler_Engine::$settings['permalink_structure'] === 'plain' && current_user_can( 'manage_options' ) ) {
+        if ( empty( get_option( 'permalink_structure' ) ) ) {
             printf(
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -179,6 +179,11 @@ final class Cache_Enabler_Disk {
                 $switch = true;
                 switch_to_blog( $blog_id );
             }
+
+            if ( isset( $GLOBALS['switched'] ) && $GLOBALS['switched'] === true ) {
+                global $wp_rewrite;
+                $wp_rewrite->init(); // reinitialize rewrite rules to pick up correct data for url_to_postid() and user_trailingslashit()
+            }
         }
 
         $args             = self::get_cache_iterator_args( $url, $args );
@@ -440,7 +445,7 @@ final class Cache_Enabler_Disk {
         }
 
         if ( in_array( 'cache_enabler_site_cache_cleared', $hooks_to_fire, true ) && empty( Cache_Enabler::get_cache_index() ) ) {
-            $site_cleared_url = self::get_cache_url(); // not using home_url() directly in case trailing slash needs to be appended
+            $site_cleared_url = user_trailingslashit( home_url() );
             $site_cleared_id  = get_current_blog_id();
 
             do_action( 'cache_enabler_site_cache_cleared', $site_cleared_url, $site_cleared_id, $cache_cleared_index );
@@ -795,8 +800,8 @@ final class Cache_Enabler_Disk {
      * @since   1.8.0
      * @change  1.8.0
      *
-     * @param   string  $dir        directory path (without trailing slash) to potentially cached page, defaults to site cache directory if empty
-     * @return  string  $cache_url  full URL to potentially cached page
+     * @param   string  $dir        directory path to potentially cached page, defaults to site cache directory if empty
+     * @return  string  $cache_url  full URL to potentially cached page (with trailing slash if the permalink structure has it)
      */
 
     private static function get_cache_url( $dir = null ) {
@@ -806,10 +811,7 @@ final class Cache_Enabler_Disk {
         }
 
         $cache_url = parse_url( home_url(), PHP_URL_SCHEME ) . '://' . str_replace( self::$cache_dir . '/', '', $dir );
-
-        if ( Cache_Enabler_Engine::$settings['permalink_structure'] === 'has_trailing_slash' ) {
-            $cache_url .= ( $cache_url !== home_url() || ! empty( Cache_Enabler::get_blog_path() ) ) ? '/' : '';
-        }
+        $cache_url = user_trailingslashit( $cache_url );
 
         return $cache_url;
     }

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -246,7 +246,7 @@ final class Cache_Enabler_Engine {
      * check permalink structure
      *
      * @since   1.5.0
-     * @change  1.5.0
+     * @change  1.8.0
      *
      * @return  boolean  true if request URI does not match permalink structure or if plain, false otherwise
      */
@@ -254,21 +254,12 @@ final class Cache_Enabler_Engine {
     private static function is_wrong_permalink_structure() {
 
         // check if trailing slash is set and missing (ignoring root index and file extensions)
-        if ( self::$settings['permalink_structure'] === 'has_trailing_slash' ) {
+        if ( self::$settings['use_trailing_slashes'] ) {
             if ( preg_match( '/\/[^\.\/\?]+(\?.*)?$/', $_SERVER['REQUEST_URI'] ) ) {
                 return true;
             }
-        }
-
-        // check if trailing slash is not set and appended (ignoring root index and file extensions)
-        if ( self::$settings['permalink_structure'] === 'no_trailing_slash' ) {
-            if ( preg_match( '/\/[^\.\/\?]+\/(\?.*)?$/', $_SERVER['REQUEST_URI'] ) ) {
-                return true;
-            }
-        }
-
-        // check if custom permalink structure is not set
-        if ( self::$settings['permalink_structure'] === 'plain' ) {
+        // check if trailing slash is not set and appended otherwise (ignoring root index and file extensions)
+        } elseif ( preg_match( '/\/[^\.\/\?]+\/(\?.*)?$/', $_SERVER['REQUEST_URI'] ) ) {
             return true;
         }
 


### PR DESCRIPTION
Update permalink structure handling to use the [`$use_trailing_slashes`](https://github.com/WordPress/wordpress-develop/blob/bedd023c3ae3e2d1d1594eca3184d4b719af02fa/src/wp-includes/class-wp-rewrite.php#L34-L40) class property in the [`WP_Rewrite`](https://developer.wordpress.org/reference/classes/wp_rewrite/) class instead of the [`Cache_Enabler::get_permalink_structure()`](https://github.com/keycdn/cache-enabler/blob/6ce1426fb53ae942f7c4cd8e96a74da6413e5fba/inc/cache_enabler.class.php#L589-L617) method. This performs the check when that class is initialized and does it better as [it uses `substr()`](https://github.com/WordPress/wordpress-develop/blob/bedd023c3ae3e2d1d1594eca3184d4b719af02fa/src/wp-includes/class-wp-rewrite.php#L1909) instead of `preg_match()`. I was unaware of this class property when creating this handling in the past. Deprecate the `Cache_Enabler::get_permalink_structure()` method and leave the `permalink_structure` setting in the settings file for now.

Update the URL in the `Cache_Enabler::process_clear_cache_request()` method to not have a scheme because this is no longer required since PR #237.

Update the cache iterator to reinitialize the rewrite rules if the blog has been switched. Switching the blog can occur in the cache iterator itself, or beforehand in `Cache_Enabler::each_site()`. That is why `$GLOBALS['switched']` is being checked instead of doing it in the conditional above. This is required to ensure the [`$permalink_structure`](https://github.com/WordPress/wordpress-develop/blob/bedd023c3ae3e2d1d1594eca3184d4b719af02fa/src/wp-includes/class-wp-rewrite.php#L26-L32), [`$use_trailing_slashes`](https://github.com/WordPress/wordpress-develop/blob/bedd023c3ae3e2d1d1594eca3184d4b719af02fa/src/wp-includes/class-wp-rewrite.php#L34-L40), and [`$use_verbose_page_rules`](https://github.com/WordPress/wordpress-develop/blob/bedd023c3ae3e2d1d1594eca3184d4b719af02fa/src/wp-includes/class-wp-rewrite.php#L251-L266) class properties are up to date for the [`url_to_postid()`](https://developer.wordpress.org/reference/functions/url_to_postid/) and [`user_trailingslashit()`](https://developer.wordpress.org/reference/functions/user_trailingslashit/) functions that follow. This is somewhat expensive but is required. If this was not called then the originating site `WP_Rewrite` instance would be used because [`switch_to_blog()`](https://developer.wordpress.org/reference/functions/switch_to_blog/) does not track the rewrite state of the old and new site. That would result in potentially returning the wrong post IDs and appending/stripping the trailing slash for all sites based on the permalink structure of the originating site.

Update the `Cache_Enabler_Disk::get_cache_url()` method to be more simple. Always append or remove the trailing slash, even if it is the home page. This means the `$site_cleared_url` in the `cache_enabler_site_cache_cleared` hook will now have the same behavior. In version 1.7.2 and before this never had a trailing slash as it did not take into account the site's settings. Since PR #237 this would append the trailing slash if set but not the home page.

Update the `Cache_Enabler_Engine::is_wrong_permalink_structure()` method to only check the trailing slash instead of if the permalink structure is plain. (If a permalink structure is plain it does not use trailing slashes.) This means we will no longer always be bypassing the cache if a custom permalink structure in not set. Instead, a warning will be displayed as it has been and only the home page will be cached by default (as it does not have a query string). All pages, such as `https://example.com/?p=123` and `https://example.com/?page_id=321`, will bypass the cache by default due to the query string.