### PR TITLE
update trailing asterisk check

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1980,7 +1980,7 @@ final class Cache_Enabler {
 
         $url_path = (string) parse_url( $url, PHP_URL_PATH );
 
-        if ( substr( $url_path, -1 ) === '*' ) {
+        if ( substr( $url_path, -1, 1 ) === '*' ) {
             $url_path_pieces  = explode( '/', $url_path );
             $wildcard_subpage = end( $url_path_pieces );
             $new_url_path     = substr( $url_path, 0, -strlen( $wildcard_subpage ) );

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -504,7 +504,7 @@ final class Cache_Enabler_Disk {
 
             foreach ( $filter_value as $filter_object ) {
                 // if trailing asterisk exists remove it to allow a wildcard match
-                if ( substr( $filter_object, -1 ) === '*' ) {
+                if ( substr( $filter_object, -1, 1 ) === '*' ) {
                     $filter_object = substr( $filter_object, 0, -1 );
                 // maybe append trailing slash to force a strict match otherwise
                 } else {


### PR DESCRIPTION
Update the `substr()` function to be more strict and only ever return a string with a length of 1 when checking for a trailing asterisk.

This updates what was added in PR #245 and #246.