### PR TITLE
update getting cache file

### DIFF
--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -417,24 +417,23 @@ final class Cache_Enabler_Engine {
 
         $cache_file = Cache_Enabler_Disk::get_cache_file();
 
-        if ( Cache_Enabler_Disk::cache_exists( $cache_file ) && ! Cache_Enabler_Disk::cache_expired( $cache_file ) && ! self::bypass_cache()  ) {
-            // set X-Cache-Handler response header
+        if ( Cache_Enabler_Disk::cache_exists( $cache_file ) && ! Cache_Enabler_Disk::cache_expired( $cache_file ) && ! self::bypass_cache() ) {
             header( 'X-Cache-Handler: cache-enabler-engine' );
 
-            // return 304 Not Modified with empty body if applicable
             if ( strtotime( self::$request_headers['If-Modified-Since'] >= filemtime( $cache_file ) ) ) {
                 header( $_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified', true, 304 );
-                exit;
+                exit; // deliver empty body
             }
 
-            // set Content-Encoding response header if applicable
-            if ( strpos( basename( $cache_file ), 'br' ) !== false ) {
-                header( 'Content-Encoding: br' );
-            } elseif ( strpos( basename( $cache_file ), 'gz' ) !== false ) {
-                header( 'Content-Encoding: gzip' );
+            switch ( substr( $cache_file, -2, 2 ) ) {
+                case 'br':
+                    header( 'Content-Encoding: br' );
+                    break;
+                case 'gz':
+                    header( 'Content-Encoding: gzip' );
+                    break;
             }
 
-            // deliver cache
             readfile( $cache_file );
             exit;
         }


### PR DESCRIPTION
Update getting the cache file by having the `Cache_Enabler_Disk::get_cache_file()` method set a property for the cache file path that has been generated. This will prevent having to build the file path again when a cached page is created after failing to be delivered.

I did not test it but I believe this will fix what was occurring in https://wordpress.org/support/topic/event-archive-cached-as-home-page/ (it may no longer be an issue as that plugin had changes made to address this issue recently). This would be due to now only using the file path to a cached page based on the originating `$_SERVER['REQUEST_URI']` instead of checking this value again after the output buffering has ended (where in that time it could have been overwritten).

This updates what was added in PR #211.