### PR TITLE
update WP-CLI clear subcommand

### DIFF
--- a/inc/cache_enabler_cli.class.php
+++ b/inc/cache_enabler_cli.class.php
@@ -35,11 +35,11 @@ class Cache_Enabler_CLI {
      *    $ wp cache-enabler clear --ids=1,2,3
      *    Success: Pages cache cleared.
      *
-     *    # Clear the page cache for a particular URL.
-     *    $ wp cache-enabler clear --urls=https://www.example.com/about-us/
+     *    # Clear the page cache for a particular URL (with or without scheme).
+     *    $ wp cache-enabler clear --urls=www.example.com/about-us/
      *    Success: Page cache cleared.
      *
-     *    # Clear all pages cache for sites with blog IDs 1, 2, and 3.
+     *    # Clear the page cache for sites with blog IDs 1, 2, and 3.
      *    $ wp cache-enabler clear --sites=1,2,3
      *    Success: Sites cache cleared.
      *
@@ -57,19 +57,16 @@ class Cache_Enabler_CLI {
             )
         );
 
-        // clear complete cache if no associative arguments are given
-        if ( empty( $assoc_args['ids'] ) && empty( $assoc_args['urls'] ) && empty( $assoc_args['sites'] ) ) {
+        if ( $assoc_args['ids'] === '' && $assoc_args['urls'] === '' && $assoc_args['sites'] === '' ) {
             Cache_Enabler::clear_complete_cache();
 
             return WP_CLI::success( ( is_multisite() ) ? esc_html__( 'Network cache cleared.', 'cache-enabler' ) : esc_html__( 'Site cache cleared.', 'cache-enabler' ) );
         }
 
-        // clear page(s) cache by post ID(s) and/or URL(s)
-        if ( ! empty( $assoc_args['ids'] ) || ! empty( $assoc_args['urls'] ) ) {
+        if ( $assoc_args['ids'] !== '' || $assoc_args['urls'] !== '' ) {
             array_map( 'Cache_Enabler::clear_page_cache_by_post', explode( ',', $assoc_args['ids'] ) );
             array_map( 'Cache_Enabler::clear_page_cache_by_url', explode( ',', $assoc_args['urls'] ) );
 
-            // check if there is more than one ID and/or URL
             $separators = substr_count( $assoc_args['ids'], ',' ) + substr_count( $assoc_args['urls'], ',' );
 
             if ( $separators > 0 ) {
@@ -79,11 +76,9 @@ class Cache_Enabler_CLI {
             }
         }
 
-        // clear pages cache by blog ID(s)
-        if ( ! empty( $assoc_args['sites'] ) ) {
+        if ( $assoc_args['sites'] !== '' ) {
             array_map( 'Cache_Enabler::clear_page_cache_by_site', explode( ',', $assoc_args['sites'] ) );
 
-            // check if there is more than one site
             $separators = substr_count( $assoc_args['sites'], ',' );
 
             if ( $separators > 0 ) {
@@ -95,5 +90,4 @@ class Cache_Enabler_CLI {
     }
 }
 
-// add WP-CLI command
 WP_CLI::add_command( 'cache-enabler', 'Cache_Enabler_CLI' );

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -153,6 +153,10 @@ final class Cache_Enabler_Disk {
             'size'  => 0,
         );
 
+        if ( empty( $url ) ) {
+            return $cache;
+        }
+
         $url       = esc_url_raw( $url, array( 'http', 'https' ) );
         $cache_dir = self::get_cache_dir( $url );
 
@@ -961,7 +965,7 @@ final class Cache_Enabler_Disk {
             $settings = include $settings_file;
         } else {
             $fallback      = true;
-            $settings_file = self::get_settings_file( true );
+            $settings_file = self::get_settings_file( $fallback );
 
             if ( is_file( $settings_file ) ) {
                 $settings = include $settings_file;


### PR DESCRIPTION
Update the WP-CLI `clear` subcommand to check for an empty string instead of using the `empty()` function. This will make it so `wp cache-enabler clear --ids=0`, `wp cache-enabler clear --urls=0`, and `wp cache-enabler clear --sites=0` will not clear the complete cache. `wp cache-enabler clear --sites=0` will now clear the current blog ID due to how the [`get_site()`](https://developer.wordpress.org/reference/functions/get_site/) function works, while the others will now not clear anything.

The status returned by WP-CLI will be improved when the return handling is improved across the code base (due to the changes introduced with the new cache iterator). That will allow WP-CLI to indicate whether or not the cache was actually cleared. For now the status being returned stays as it has been.

Add an `empty()` check to the cache iterator to prevent the `Cache_Enabler_Disk::get_cache_dir()` method from returning the cache directory to the currently requested URL (updating what was initially added in PR #237).