### PR TITLE
fix permalink structure handling

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -702,7 +702,7 @@ final class Cache_Enabler {
 
         $system_default_settings = array(
             'version'              => (string) CACHE_ENABLER_VERSION,
-            'use_trailing_slashes' => (int) $GLOBALS['wp_rewrite']->use_trailing_slashes,
+            'use_trailing_slashes' => (int) ( substr( get_option( 'permalink_structure' ), -1, 1 ) === '/' ),
             'permalink_structure'  => (string) self::get_permalink_structure(), // deprecated in 1.8.0
         );
 


### PR DESCRIPTION
Fix permalink structure handling for multisites from a change made in PR #251. When using [`switch_to_blog()`](https://developer.wordpress.org/reference/functions/switch_to_blog/) beforehand this can result in the wrong `$GLOBALS['wp_rewrite']->use_trailing_slashes` being returned (as explained in that PR). That would result in the originating site permalink structure being used in some cases instead of from the switched-to site. I do not think it is worth reinitializing this class to get the correct value for only this property (like we do in the cache iterator). Instead, use what the `WP_Rewrite` classes uses to generate the value assigned to this property when instantiated.