### PR TITLE
update conditional statements

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1459,9 +1459,7 @@ final class Cache_Enabler {
 
         if ( empty( $user ) ) {
             $user = wp_get_current_user();
-        }
-
-        if ( is_numeric( $user ) ) {
+        } elseif ( is_numeric( $user ) ) {
             $user = get_userdata( $user );
         }
 
@@ -1739,9 +1737,7 @@ final class Cache_Enabler {
 
         if ( empty( $author ) ) {
             $author = wp_get_current_user();
-        }
-
-        if ( is_numeric( $author ) ) {
+        } elseif ( is_numeric( $author ) ) {
             $author = get_userdata( $author );
         }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -516,8 +516,8 @@ final class Cache_Enabler_Disk {
                 if ( substr( $filter_object, -1, 1 ) === '*' ) {
                     $filter_object = substr( $filter_object, 0, -1 );
                 // maybe append trailing slash to force a strict match otherwise
-                } else {
-                    $filter_object = $filter_object . ( ( is_dir( $dir_object ) ) ? '/' : '' );
+                } elseif ( is_dir( $dir_object ) ) {
+                    $filter_object = $filter_object . '/';
                 }
 
                 if ( str_replace( $filter_object, '', $dir_object ) !== $dir_object ) {


### PR DESCRIPTION
Update conditional statements checking for a numeric user ID to be an `elseif` instead of a separate `if` statement. There is no reason to check this if the value was empty beforehand and set as the current user `WP_User` instance. This updates what was added in PR #247.

Update conditional statement in the directory object filter to be an `elseif` statement instead of an `else` statement. Using a ternary operator makes no sense here. This updates what was added in PR #252.