### PR TITLE
update cache size transient

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -274,10 +274,9 @@ final class Cache_Enabler {
             } else {
                 $changed_cache_size = array_sum( current( $index )['versions'] );
                 $new_cache_size     = $current_cache_size + $changed_cache_size; // changed cache size is negative if cache cleared
+                $new_cache_size     = ( $new_cache_size >= 0 ) ? $new_cache_size : 0;
 
-                if ( $new_cache_size >= 0 ) {
-                    set_transient( 'cache_enabler_cache_size', $new_cache_size, HOUR_IN_SECONDS );
-                }
+                set_transient( 'cache_enabler_cache_size', $new_cache_size, DAY_IN_SECONDS );
             }
         }
     }
@@ -696,7 +695,7 @@ final class Cache_Enabler {
             $cache = Cache_Enabler_Disk::cache_iterator( home_url(), $args );
             $cache_size = $cache['size'];
 
-            set_transient( 'cache_enabler_cache_size', $cache_size, HOUR_IN_SECONDS );
+            set_transient( 'cache_enabler_cache_size', $cache_size, DAY_IN_SECONDS );
         }
 
         return $cache_size;


### PR DESCRIPTION
Update the `cache_enabler_cache_size` transient to expire after 1 day instead of 1 hour. This will help the new real-time cache size handling perform better on low traffic sites with the cache being regularly generated. For sites that have every page cached this transient would expire after 1 day and then only be rebuilt when displayed in the WordPress dashboard. Based on the feedback we can adjust this value and/or add a filter hook.

Update the `Cache_Enabler::on_cache_created_cleared()` method to always set the transient when the cache size has changed (instead of only if `$new_cache_size` is greater than or equal to `0`). The cache size never goes negative, but let us be strict and validate what is being set.

This updates what was added in PR #237.