### PR TITLE
update engine restart

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -700,22 +700,27 @@ final class Cache_Enabler {
     /**
      * Get the plugin settings from the database for the current site.
      *
-     * This will update the disk and backend requirements and then clear the complete
+     * This can update the disk and backend requirements and then clear the complete
      * cache if the settings do not exist or are outdated. If that occurs, the
      * settings after the update will be returned.
      *
      * @since   1.5.0
+     * @since   1.8.0  The `$update` parameter was added.
      * @change  1.8.0
      *
-     * @return  array  Plugin settings from the database.
+     * @param   bool   $update  Whether to update the disk and backend requirements if the settings are
+     *                          outdated. Default true.
+     * @return  array           Plugin settings from the database.
      */
-    public static function get_settings() {
+    public static function get_settings( $update = true ) {
 
         $settings = get_option( 'cache_enabler' );
 
         if ( $settings === false || ! isset( $settings['version'] ) || $settings['version'] !== CACHE_ENABLER_VERSION ) {
-            self::update();
-            $settings = self::get_settings();
+            if ( $update ) {
+                self::update();
+                $settings = self::get_settings( false );
+            }
         }
 
         return $settings;

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -998,17 +998,20 @@ final class Cache_Enabler_Disk {
      * Get the plugin settings from the settings file for the current site.
      *
      * This will create the settings file if it does not exist and the cache engine
-     * was started late. It will also update the disk and backend requirements and
-     * then clear the complete cache if the settings are outdated. Having the backend
-     * updated will trigger a new settings file to be created, which would result in
-     * this returning the settings from that new file afterward.
+     * was started late. It can update the disk and backend requirements and then
+     * clear the complete cache if the settings are outdated. Having the backend
+     * updated will trigger a new settings file to be created, which if created would
+     * result in this returning the settings from that new file.
      *
      * @since   1.5.0
+     * @since   1.8.0  The `$update` parameter was added.
      * @change  1.8.0
      *
-     * @return  array  Plugin settings from the settings file, empty array on failure.
+     * @param   bool   $update  Whether to update the disk and backend requirements if the settings are
+     *                          outdated. Default true.
+     * @return  array           Plugin settings from the settings file, empty array on failure.
      */
-    public static function get_settings() {
+    public static function get_settings( $update = true ) {
 
         $settings      = array();
         $settings_file = self::get_settings_file();
@@ -1032,9 +1035,11 @@ final class Cache_Enabler_Disk {
 
         if ( empty( $settings ) && class_exists( 'Cache_Enabler' ) ) {
             if ( $outdated_settings ) {
-                Cache_Enabler::update();
-                wp_opcache_invalidate( $settings_file );
-                $settings = self::get_settings();
+                if ( $update ) {
+                    Cache_Enabler::update();
+                    wp_opcache_invalidate( $settings_file );
+                    $settings = self::get_settings( false );
+                }
             } else {
                 $settings_file = self::create_settings_file( Cache_Enabler::get_settings() );
 

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -64,10 +64,12 @@ final class Cache_Enabler_Engine {
     /**
      * Constructor.
      *
-     * This is called by self::start() and starts up the cache engine. In a cache
-     * engine restart the WordPress rewrite component will be reinitialized. This is
-     * to pick up the correct data for url_to_postid(), user_trailingslashit(), and
-     * the pagination bases.
+     * This is called by self::start() and starts up the cache engine. If the cache
+     * engine is already started that means it is being restarted. If that occurs the
+     * WordPress rewrite component will be reinitialized. This is to pick up the
+     * correct data for url_to_postid(), user_trailingslashit(), and the pagination
+     * bases. The disk and backend requirements will not be updated if the cache
+     * engine is being restarted and the settings do not exist or are outdated.
      *
      * @since   1.5.0
      * @change  1.8.0
@@ -84,9 +86,9 @@ final class Cache_Enabler_Engine {
         self::$request_headers = self::get_request_headers();
 
         if ( self::is_index() ) {
-            self::$settings = Cache_Enabler_Disk::get_settings();
+            self::$settings = Cache_Enabler_Disk::get_settings( ! self::$started );
         } elseif ( class_exists( 'Cache_Enabler' ) ) {
-            self::$settings = Cache_Enabler::get_settings();
+            self::$settings = Cache_Enabler::get_settings( ! self::$started );
             Cache_Enabler::$options = self::$settings; // Deprecated in 1.5.0.
             Cache_Enabler::$options['webp'] = self::$settings['convert_image_urls_to_webp']; // Deprecated in 1.5.0.
         }


### PR DESCRIPTION
Update the cache engine to not update the disk and backend requirements when restarted. This will also make sure the update is not attempted endless times if it failed for some reason.

This updates #271.