### PR TITLE
update deleting settings file

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -451,6 +451,10 @@ final class Cache_Enabler {
             } else {
                 self::clear_cache_on_option_save( $option, $old_value, $value );
             }
+
+            if ( $option === 'home' ) {
+                Cache_Enabler_Disk::delete_settings_file();
+            }
         }
     }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1572,7 +1572,7 @@ final class Cache_Enabler_Disk {
      * @param  string  (Optional) Path to the settings file. Default is the settings file for the
      *                 current site.
      */
-    private static function delete_settings_file( $settings_file = null ) {
+    public static function delete_settings_file( $settings_file = null ) {
 
         if ( empty( $settings_file ) ) {
             $settings_file = self::get_settings_file();


### PR DESCRIPTION
Update the settings file to be deleted before the `home` option is updated in the database. That option is the Site Address (URL) setting. This will prevent a leftover settings file.