### PR TITLE
fix cache clearing structure for option actions

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -523,6 +523,10 @@ final class Cache_Enabler {
 
         if ( in_array( $option, $options, true ) ) {
             self::clear_cache_on_option_save( $option, $old_value, $value );
+
+            if ( $option === 'permalink_structure' ) {
+                self::update_backend();
+            }
         }
     }
 


### PR DESCRIPTION
Update the backend after the `permalink_structure` option has been updated. This did not make it in the conversion in PR #272, which means this is not new behavior and should have been added in that PR.