### PR TITLE
update events scheduling

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2424,8 +2424,10 @@ final class Cache_Enabler {
         $events = self::get_events();
 
         foreach ( $events as $hook => $recurrence ) {
-            if ( $hook === 'cache_enabler_clear_expired_cache' && ! Cache_Enabler_Engine::$settings['cache_expires'] ) {
-                continue; // Skip to next event because cache does not expire.
+            if ( $hook === 'cache_enabler_clear_expired_cache' ) {
+                if ( ! Cache_Enabler_Engine::$settings['cache_expires'] || Cache_Enabler_Engine::$settings['cache_expiry_time'] === 0 ) {
+                    continue;
+                }
             }
 
             if ( ! wp_next_scheduled( $hook ) ) {


### PR DESCRIPTION
Update the events scheduling to not schedule the `cache_enabler_clear_expired_cache` event if the cache expiry time is 0, which is what we also check for in `Cache_Enabler_Disk::cache_expired()`. This value cannot be saved any lower.

This updates what was added in PR #268.