### PR TITLE
update advanced-cache.php handling

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -2,9 +2,9 @@
 /**
  * The advanced-cache.php drop-in file for Cache Enabler.
  *
- * The advanced-cache.php creation method uses this during the disk setup and requirements
- * check. You can copy this file, edit the $cache_enabler_constants_file value, and save it
- * as "advanced-cache.php" in the wp-content directory.
+ * The advanced-cache.php creation method uses this during the disk setup and
+ * requirements check. You can copy this file to the wp-content directory and
+ * edit the $cache_enabler_constants_file value as needed.
  *
  * @since   1.2.0
  * @change  1.8.0

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2270,10 +2270,9 @@ final class Cache_Enabler {
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(
                     // translators: 1. Cache Enabler 2. advanced-cache.php 3. wp-content/plugins/cache-enabler 4. wp-content
-                    esc_html__( '%1$s was unable to create the required %2$s drop-in file. You can manually create it by locating the sample file named %3$s (located in the %4$s directory), editing it as required, and then saving it as %2$s in the %5$s directory.', 'cache-enabler' ),
+                    esc_html__( '%1$s was unable to create the required %2$s drop-in file. You can manually create it by locating the sample file in the %3$s directory, editing it as needed, and then saving it in the %4$s directory.', 'cache-enabler' ),
                     '<strong>Cache Enabler</strong>',
                     '<code>advanced-cache.php</code>',
-                    '<code>advanced-cache-sample.php</code>',
                     '<code>' . str_replace( ABSPATH, '', CACHE_ENABLER_DIR ) . '</code>',
                     '<code>' . basename( WP_CONTENT_DIR ) . '</code>'
                 )

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -279,7 +279,7 @@ final class Cache_Enabler_Disk {
      */
     public static function create_advanced_cache_file() {
 
-        $advanced_cache_sample_file = CACHE_ENABLER_DIR . '/advanced-cache-sample.php';
+        $advanced_cache_sample_file = CACHE_ENABLER_DIR . '/advanced-cache.php';
 
         if ( ! is_readable( $advanced_cache_sample_file ) ) {
             return false;


### PR DESCRIPTION
Rename the `advanced-cache-sample.php` file to `advanced-cache.php` for backward compatibility when updating from a couple old versions with a certain setting enabled. More specifically, any version from 1.2.3 (may be earlier) to 1.3.5 and the "Clear the complete cache if any plugin has been upgraded" setting was enabled. If this is not done then a PHP warning will occur due to a file not existing when trying to be copied. I believe this will be better than the alternative of leaving an empty `advanced-cache.php` file and then leaving `advanced-cache-sample.php`.

This updates the changes made in PR #260.