### PR TITLE
update cache size transient handling

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,9 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 == Changelog ==
 
+= 1.8.2 =
+* Update cache size transient handling (#287)
+
 = 1.8.1 =
 * Fix requirements check (#285)
 


### PR DESCRIPTION
Update `Cache_Enabler::on_cache_created_cleared()` to only call `Cache_Enabler::get_cache_size()` when the `cache_enabler_cache_size` transient does not exist and the changed cache size is positive (so when a cached page has been created). This will prevent calling this unnecessarily and way too often.

The issue was as soon as a page being cleared had an index count greater than 1, like if a paginated page had been cleared, it would delete the transient. The following call to `Cache_Enabler::on_cache_created_cleared()` would call `Cache_Enabler::get_cache_size()` because the cache size transient no longer exists (`Cache_Enabler::on_cache_created_cleared()` can be called several times during one cache clear query, like clearing the post cache after a post has been updated). The following calls may or may not do the same thing, which means it could use up a lot of resources in certain situations when going back and forth like this. It was not an issue for when the site cache was being cleared.

This updates what was added in PR #237 and updated in PR #269.