### PR TITLE
update index file handling

### DIFF
--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -182,14 +182,24 @@ final class Cache_Enabler_Engine {
     /**
      * Whether the script being executed is the installation directory index file.
      *
+     * This uses $_SERVER['SCRIPT_NAME'] instead of $_SERVER['SCRIPT_FILENAME']
+     * because it is in the CGI/1.1 specification. It checks whether
+     * CACHE_ENABLER_INDEX_FILE ends with $_SERVER['SCRIPT_NAME'].
+     *
      * @since   1.5.0
-     * @change  1.8.0
+     * @change  1.8.3
      *
      * @return  bool  True if the script being executed is the index file, false if not.
      */
     private static function is_index() {
 
-        if ( defined( 'CACHE_ENABLER_INDEX_FILE' ) && $_SERVER['SCRIPT_FILENAME'] === CACHE_ENABLER_INDEX_FILE ) {
+        if ( ! defined( 'CACHE_ENABLER_INDEX_FILE' ) ) {
+            return false;
+        }
+
+        $script_name_length = strlen( $_SERVER['SCRIPT_NAME'] );
+
+        if ( substr( CACHE_ENABLER_INDEX_FILE, -$script_name_length, $script_name_length ) === $_SERVER['SCRIPT_NAME'] ) {
             return true;
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,9 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 == Changelog ==
 
+= 1.8.3 =
+* Update index file handling (#289)
+
 = 1.8.2 =
 * Update cache size transient handling (#287)
 


### PR DESCRIPTION
Update the `Cache_Enabler_Engine::is_index()` method to use the `$_SERVER['SCRIPT_NAME']` again like it was before PR #260 as this is in the [CGI/1.1 specification](http://www.faqs.org/rfcs/rfc3875.html), making it a more reliable superglobal. This method will now check if the `CACHE_ENABLER_INDEX_FILE` constant ends with `$_SERVER['SCRIPT_NAME']` instead of if it equals `$_SERVER['SCRIPT_FILENAME']`.