### PR TITLE
fix plugin upgrade process

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1002,18 +1002,20 @@ final class Cache_Enabler_Disk {
      * Get the plugin settings from the settings file for the current site.
      *
      * This will create the settings file if it does not exist and the cache engine
-     * was started late. It can update the disk and backend requirements and then
-     * clear the complete cache if the settings are outdated. Having the backend
-     * updated will trigger a new settings file to be created, which if created would
-     * result the settings from that new file being returned.
+     * was started late. If that occurs, the settings from the new settings file will
+     * be returned.
+     *
+     * This can update the disk and backend requirements and then clear the complete
+     * cache if the settings are outdated. If that occurs, a new settings file will be
+     * created and an empty array returned.
      *
      * @since   1.5.0
      * @since   1.8.0  The `$update` parameter was added.
-     * @change  1.8.0
+     * @change  1.8.5
      *
      * @param   bool   $update  Whether to update the disk and backend requirements if the settings are
      *                          outdated. Default true.
-     * @return  array           Plugin settings from the settings file, empty array on failure.
+     * @return  array           Plugin settings from the settings file, empty array when outdated or on failure.
      */
     public static function get_settings( $update = true ) {
 
@@ -1041,8 +1043,6 @@ final class Cache_Enabler_Disk {
             if ( $outdated_settings ) {
                 if ( $update ) {
                     Cache_Enabler::update();
-                    wp_opcache_invalidate( $settings_file );
-                    $settings = self::get_settings( false );
                 }
             } else {
                 $settings_file = self::create_settings_file( Cache_Enabler::get_settings() );

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Cache Enabler ===
 Contributors: keycdn
 Tags: cache, caching, performance, webp, gzip, brotli, mobile, speed
-Requires at least: 5.5
+Requires at least: 5.1
 Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: trunk
@@ -54,6 +54,10 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 
 == Changelog ==
+
+= 1.8.5 =
+* Update required WordPress version from 5.5 to 5.1 (#295)
+* Fix plugin upgrade process when disk settings are outdated and a frontend page is requested (#295)
 
 = 1.8.4 =
 * Update `advanced-cache.php` drop-in file handling (#292)


### PR DESCRIPTION
Fix plugin upgrade process when the disk settings are outdated and a frontend page is requested. Update `Cache_Enabler_Disk::get_settings()` to return an empty array when the disk and backend requirements are updated instead of trying to get the newly created settings file contents. This does not affect the caching behavior as the following will still occur when the disk settings are outdated and a frontend page is requested:

1. First frontend page request finds the settings are outdated so the disk and backend requirements are updated. No cached page is delivered. If this occurs on a multisite network then each site that has Cache Enabler installed will be updated.

2. Second frontend page request pulls the settings from the newly created settings file and creates the cached page. No cached page is delivered.

3. Third frontend page request pulls the settings from the newly created settings file again and delivers the cached page.

It appears this plugin upgrade process occurs in the backend most of the time, which means the above does not happen often. In that case I do not think it is worth adding more complexity to have this method return the disk settings after an update as it will actually not improve the caching behavior. The only thing I know this will affect is the event scheduling because the cache engine will not be started in the first frontend page request shown above. That means `Cache_Enabler::schedule_events()` will not be completed until the second frontend page request when the cache engine is started after the disk and backend requirements were updated.

This lowers the WordPress required version back to 5.1.

This fixes #294 and what was originally introduced in PR #260.