### PR TITLE
Allow user to set their own cache_enabler_constants_file to bypass hardcoded path usage

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -288,7 +288,8 @@ final class Cache_Enabler_Disk {
 
         $advanced_cache_file          = WP_CONTENT_DIR . '/advanced-cache.php';
         $advanced_cache_file_contents = file_get_contents( $advanced_cache_sample_file );
-        $advanced_cache_file_contents = str_replace( '/your/path/to/wp-content/plugins/cache-enabler', CACHE_ENABLER_DIR, $advanced_cache_file_contents );
+        $replace = "defined('CACHE_ENABLER_CONSTANTS_FILE') ? CACHE_ENABLER_CONSTANTS_FILE : '" . CACHE_ENABLER_DIR . "/constants.php'";
+        $advanced_cache_file_contents = str_replace( '\'/your/path/to/wp-content/plugins/cache-enabler/constants.php\'', $replace, $advanced_cache_file_contents );
 
         if ( ! is_writable( dirname( $advanced_cache_file ) ) ) {
             return false;


### PR DESCRIPTION
The changes introduced in https://github.com/keycdn/cache-enabler/pull/260 now set a `$cache_enabler_constants_file` variable with a hardcoded path.

I'm using [Deployer](https://deployer.org/), which uses a [Capistrano like structure](https://capistranorb.com/documentation/getting-started/structure/) to deploy a project. I currently end up with something like: `/var/www/releases/5/public/wp-content/plugins/cache-enabler/constants.php`

But this path changes each time I deploy a new release. I tried to set it manually but the file contents is overwritten upon deactivation/activation.

Solution : introduce a new constant which, when defined, will be used instead. It will fallback on the hardcoded path if not defined.
