### PR TITLE
update advanced-cache.php handling

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -3,11 +3,12 @@
  * The advanced-cache.php drop-in file for Cache Enabler.
  *
  * The advanced-cache.php creation method uses this during the disk setup and
- * requirements check. You can copy this file to the wp-content directory and
- * edit the $cache_enabler_constants_file value as needed.
+ * requirements check. You can copy this file to the wp-content directory and edit
+ * the $cache_enabler_constants_file value as needed. It will be deleted if stale
+ * or abandoned.
  *
  * @since   1.2.0
- * @change  1.8.0
+ * @change  1.8.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -30,4 +31,6 @@ if ( file_exists( $cache_enabler_constants_file ) ) {
             Cache_Enabler_Engine::start_buffering();
         }
     }
+} elseif ( __DIR__ === WP_CONTENT_DIR ) {
+    @unlink( __FILE__ );
 }

--- a/constants.php
+++ b/constants.php
@@ -6,15 +6,16 @@
  */
 
 $cache_enabler_constants = array(
-    'CACHE_ENABLER_VERSION'      => '1.8.5',
-    'CACHE_ENABLER_MIN_PHP'      => '5.6',
-    'CACHE_ENABLER_MIN_WP'       => '5.5',
-    'CACHE_ENABLER_DIR'          => __DIR__,
-    'CACHE_ENABLER_FILE'         => __DIR__ . '/cache-enabler.php',
-    'CACHE_ENABLER_BASE'         => ( function_exists( 'wp_normalize_path' ) ) ? plugin_basename( __DIR__ . '/cache-enabler.php' ) : null,
-    'CACHE_ENABLER_CACHE_DIR'    => WP_CONTENT_DIR . '/cache/cache-enabler', // Without a trailing slash.
-    'CACHE_ENABLER_SETTINGS_DIR' => WP_CONTENT_DIR . '/settings/cache-enabler', // Without a trailing slash.
-    'CACHE_ENABLER_INDEX_FILE'   => ABSPATH . 'index.php',
+    'CACHE_ENABLER_VERSION'        => '1.8.5',
+    'CACHE_ENABLER_MIN_PHP'        => '5.6',
+    'CACHE_ENABLER_MIN_WP'         => '5.1',
+    'CACHE_ENABLER_DIR'            => __DIR__,
+    'CACHE_ENABLER_FILE'           => __DIR__ . '/cache-enabler.php',
+    'CACHE_ENABLER_BASE'           => ( function_exists( 'wp_normalize_path' ) ) ? plugin_basename( __DIR__ . '/cache-enabler.php' ) : null,
+    'CACHE_ENABLER_CACHE_DIR'      => WP_CONTENT_DIR . '/cache/cache-enabler', // Without a trailing slash.
+    'CACHE_ENABLER_SETTINGS_DIR'   => WP_CONTENT_DIR . '/settings/cache-enabler', // Without a trailing slash.
+    'CACHE_ENABLER_CONSTANTS_FILE' => __FILE__,
+    'CACHE_ENABLER_INDEX_FILE'     => ABSPATH . 'index.php',
 );
 
 foreach ( $cache_enabler_constants as $cache_enabler_constant_name => $cache_enabler_constant_value ) {

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -274,11 +274,15 @@ final class Cache_Enabler_Disk {
      * Create the advanced-cache.php drop-in file.
      *
      * @since   1.8.0
-     * @change  1.8.4
+     * @change  1.8.6
      *
      * @return  string|bool  Path to the created file, false on failure.
      */
     public static function create_advanced_cache_file() {
+
+        if ( ! is_writable( WP_CONTENT_DIR ) ) {
+            return false;
+        }
 
         $advanced_cache_sample_file = CACHE_ENABLER_DIR . '/advanced-cache.php';
 
@@ -288,13 +292,12 @@ final class Cache_Enabler_Disk {
 
         $advanced_cache_file          = WP_CONTENT_DIR . '/advanced-cache.php';
         $advanced_cache_file_contents = file_get_contents( $advanced_cache_sample_file );
-        $advanced_cache_file_contents = str_replace( '/your/path/to/wp-content/plugins/cache-enabler', CACHE_ENABLER_DIR, $advanced_cache_file_contents );
 
-        if ( ! is_writable( dirname( $advanced_cache_file ) ) ) {
-            return false;
-        }
+        $search  = '/your/path/to/wp-content/plugins/cache-enabler/constants.php';
+        $replace = CACHE_ENABLER_CONSTANTS_FILE;
 
-        $advanced_cache_file_created = file_put_contents( $advanced_cache_file, $advanced_cache_file_contents, LOCK_EX );
+        $advanced_cache_file_contents = str_replace( $search, $replace, $advanced_cache_file_contents );
+        $advanced_cache_file_created  = file_put_contents( $advanced_cache_file, $advanced_cache_file_contents, LOCK_EX );
 
         return ( $advanced_cache_file_created === false ) ? false : $advanced_cache_file;
     }


### PR DESCRIPTION
Update the `advanced-cache.php` file creation handling to use the new `CACHE_ENABLER_CONSTANTS_FILE` constant discussed in #296 (thanks @nlemoine).

Update the `advanced-cache.php` file to delete itself if considered stale or abandoned. It would be stale if the `CACHE_ENABLER_CONSTANTS_FILE` has changed after the `wp-content/advanced-cache.php` file was created (like in an example shared #296). It would be abandoned if the plugin was manually deleted, like through an FTP client. If stale, the file will be created again with the new value, which currently takes place during the requirements check.

Update the `CACHE_ENABLER_MIN_WP` constant to 5.1, which should have been updated in PR #295.