### PR TITLE
update validation for filters and page contents

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -61,7 +61,7 @@ final class Cache_Enabler_Disk {
      * Create a static HTML file from the page contents received from the cache engine.
      *
      * @since   1.5.0
-     * @change  1.7.0
+     * @change  1.8.6
      *
      * @param  string  $page_contents  Page contents from the cache engine as raw HTML.
      */
@@ -74,8 +74,8 @@ final class Cache_Enabler_Disk {
          *
          * @param  string  $page_contents  Page contents from the cache engine as raw HTML.
          */
-        $page_contents = apply_filters( 'cache_enabler_page_contents_before_store', $page_contents );
-        $page_contents = apply_filters_deprecated( 'cache_enabler_before_store', array( $page_contents ), '1.6.0', 'cache_enabler_page_contents_before_store' );
+        $page_contents = (string) apply_filters( 'cache_enabler_page_contents_before_store', $page_contents );
+        $page_contents = (string) apply_filters_deprecated( 'cache_enabler_before_store', array( $page_contents ), '1.6.0', 'cache_enabler_page_contents_before_store' );
 
         self::create_cache_file( $page_contents );
     }
@@ -306,7 +306,7 @@ final class Cache_Enabler_Disk {
      * Create a static HTML file.
      *
      * @since   1.5.0
-     * @change  1.8.0
+     * @change  1.8.6
      *
      * @param  string  $page_contents  Page contents from the cache engine as raw HTML.
      */
@@ -328,6 +328,10 @@ final class Cache_Enabler_Disk {
 
         if ( strpos( $new_cache_file_name, 'webp' ) !== false ) {
             $page_contents = self::converter( $page_contents );
+        }
+
+        if ( ! Cache_Enabler_Engine::is_cacheable( $page_contents ) ) {
+            return; // Filter, HTML minification, or WebP conversion failed.
         }
 
         switch ( substr( $new_cache_file_name, -2, 2 ) ) {
@@ -1258,7 +1262,7 @@ final class Cache_Enabler_Disk {
      * and will attempt to update any existing directories accordingly.
      *
      * @since   1.7.0
-     * @change  1.7.2
+     * @change  1.8.6
      *
      * @param   string  $dir  Directory path to create.
      * @return  bool          True if the directory either already exists or was created *and* has the
@@ -1274,7 +1278,7 @@ final class Cache_Enabler_Disk {
          * @param  int  $mode  Mode that defines the access permissions for the created directory. The mode
          *                     must be an octal number, which means it should have a leading zero. Default is 0755.
          */
-        $mode_octal  = apply_filters( 'cache_enabler_mkdir_mode', 0755 );
+        $mode_octal  = (int) apply_filters( 'cache_enabler_mkdir_mode', 0755 );
         $mode_string = decoct( $mode_octal ); // Get the last three digits (e.g. '755').
         $parent_dir  = dirname( $dir );
         $fs          = self::get_filesystem();
@@ -1414,7 +1418,7 @@ final class Cache_Enabler_Disk {
      * This handles converting inline image URLs for the WebP cache version.
      *
      * @since   1.7.0
-     * @change  1.8.0
+     * @change  1.8.6
      *
      * @param   string  $page_contents  Page contents from the cache engine as raw HTML.
      * @return  string                  Page contents after maybe being converted.
@@ -1453,8 +1457,8 @@ final class Cache_Enabler_Disk {
          *
          * @param  string  $page_contents  Page contents from the cache engine as raw HTML.
          */
-        $converted_page_contents = apply_filters( 'cache_enabler_page_contents_after_webp_conversion', preg_replace_callback( $image_urls_regex, 'self::convert_webp', $page_contents ) );
-        $converted_page_contents = apply_filters_deprecated( 'cache_enabler_disk_webp_converted_data', array( $converted_page_contents ), '1.6.0', 'cache_enabler_page_contents_after_webp_conversion' );
+        $converted_page_contents = (string) apply_filters( 'cache_enabler_page_contents_after_webp_conversion', preg_replace_callback( $image_urls_regex, 'self::convert_webp', $page_contents ) );
+        $converted_page_contents = (string) apply_filters_deprecated( 'cache_enabler_disk_webp_converted_data', array( $converted_page_contents ), '1.6.0', 'cache_enabler_page_contents_after_webp_conversion' );
 
         return $converted_page_contents;
     }

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -210,12 +210,16 @@ final class Cache_Enabler_Engine {
      * Whether the contents from the output buffer can be cached.
      *
      * @since   1.5.0
-     * @change  1.8.0
+     * @change  1.8.6
      *
      * @param   string  $contents  Contents from the output buffer.
      * @return  bool               True if contents from the output buffer are cacheable, false if not.
      */
-    private static function is_cacheable( $contents ) {
+    public static function is_cacheable( $contents ) {
+
+        if ( ! is_string( $contents ) ) {
+            return false;
+        }
 
         $has_html_tag       = ( stripos( $contents, '<html' ) !== false );
         $has_html5_doctype  = preg_match( '/^<!DOCTYPE.+html\s*>/i', ltrim( $contents ) );


### PR DESCRIPTION
Update `Cache_Enabler_Disk::create_cache_file()` to validate the page contents again before maybe compressing and then saving the new cache file. This is needed because the page contents can be modified between first checking if they're cacheable and then actually creating the cached file (through a filter, HTML minification, or WebP conversion). This should help prevent Cache Enabler from odd failures or conflicts, such as in https://wordpress.org/support/?p=14373540.

Add type casts to the following hooks:

* `cache_enabler_mkdir_mode`
* `cache_enabler_page_contents_after_webp_conversion`
* `cache_enabler_disk_webp_converted_data` (deprecated)
* `cache_enabler_page_contents_before_store`
* `cache_enabler_before_store` (deprecated)

FYI, eventually there will be better return handling here (along with other parts of the code base), allowing Cache Enabler to let users know why the cached file creation failed (which is incredibly rare).