### PR TITLE
update plugin upgrade process for multisites

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -4,8 +4,8 @@
  *
  * The advanced-cache.php creation method uses this during the disk setup and
  * requirements check. You can copy this file to the wp-content directory and edit
- * the $cache_enabler_constants_file value as needed. It will be deleted if stale
- * or abandoned.
+ * the $cache_enabler_constants_file value as needed. It will automatically delete
+ * itself if stale or abandoned.
  *
  * @since   1.2.0
  * @change  1.8.6

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -32,6 +32,9 @@ final class Cache_Enabler_Engine {
     /**
      * Whether the cache engine is started.
      *
+     * The cache engine is considered to have been started early when started in the
+     * advanced-cache.php drop-in file and started late when started on the 'init' action.
+     *
      * @since  1.5.0
      *
      * @var  bool

--- a/readme.txt
+++ b/readme.txt
@@ -55,12 +55,16 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 == Changelog ==
 
+= 1.8.7 =
+* Update plugin upgrade process for multisite networks (#303)
+* Update `wp-config.php` file handling (#302)
+
 = 1.8.6 =
-* Add `cache_enabler_settings_before_validation` filter hook (#298)
-* Add additional validation when creating cached files (#299)
-* Add type casts to several filter hooks (#299)
 * Update requirements check notices (#300)
 * Update `advanced-cache.php` drop-in file handling (#297)
+* Add additional validation when creating cached files (#299)
+* Add type casts to several filter hooks (#299)
+* Add `cache_enabler_settings_before_validation` filter hook (#298)
 
 = 1.8.5 =
 * Update required WordPress version from 5.5 to 5.1 (#295)
@@ -79,29 +83,29 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 * Fix requirements check (#285)
 
 = 1.8.0 =
-* Update `advanced-cache.php` drop-in file handling to improve reliability and compatibility (#283 and #260)
+* Update `advanced-cache.php` drop-in file handling to improve reliability and compatibility (#260 and #283)
 * Update settings file to be deleted before the `home` option is updated to prevent a leftover settings file (#279)
 * Update `cache_enabler_bypass_cache` filter hook default value to allow a complete override (#277)
-* Update cache size transient to be in real time (#269 and #237)
+* Update cache size transient to be in real time (#237 and #269)
 * Update cache expiry time to always be a non-negative integer (#265)
 * Update WP-CLI `clear` subcommand (#261)
 * Update required WordPress version from 5.1 to 5.5 (#260)
 * Update plugin upgrade process to improve reliability and compatibility (#260)
 * Update getting the cache file path to improve creating cache files (#256)
 * Update HTML5 doctype check to be less strict (#254)
-* Update permalink structure handling (#263 and #251)
-* Update requirements check to improve notices shown (#260 and #249)
+* Update permalink structure handling (#251 and #263)
+* Update requirements check to improve notices shown (#249 and #260)
 * Update cache clearing structure to enhance the automatic cache clearing actions (#247)
-* Add WP-Cron event to clear the expired cache on an hourly basis (#281, #268, and #237)
-* Add new cache clearing structure for option actions (#280 and #272)
-* Add cache engine restart support (#278 and #271)
+* Add WP-Cron event to clear the expired cache on an hourly basis (#237, #268, and #281)
+* Add new cache clearing structure for option actions (#272 and #280)
+* Add cache engine restart support (#271 and #278)
 * Add `constants.php` file to plugin directory to allow constant overrides (#260)
 * Add wildcard cache clearing support (#246)
 * Add Brotli compression support (#243 @nlemoine)
 * Add new cache clearing structure for term actions (#234 @davelit)
 * Add cache iterator to improve cache object handling (#237)
 * Fix WebP URL conversion edge case (#275)
-* Deprecate `cache_enabler_clear_site_cache_by_blog_id` and `cache_enabler_clear_page_cache_by_post_id` action hooks in favor of replacements (#274 and #247)
+* Deprecate `cache_enabler_clear_site_cache_by_blog_id` and `cache_enabler_clear_page_cache_by_post_id` action hooks in favor of replacements (#247 and #274)
 
 = 1.7.2 =
 * Update string to be translatable (#235 @timse201)


### PR DESCRIPTION
Update the process for when the disk and backend requirements are updated for multisite networks to not all be done at once because that does not scale well.

There is a caveat of this change and it is related to the `cache_enabler_disk_updated` site transient. An edge case could arise when this plugin is used on a multisite network as a must-use plugin, so there is no activation/deactivation/uninstalling occurring, and the following occurs within an hour:

1. Update plugin.
2. Forcefully delete the plugin (e.g. SFTP or FTP).
3. Install an older version of the plugin.
4. Update the plugin to the same version as in step 1.

The edge case would be the disk requirements would not be updated because the site transient would still exist thinking it already updated itself. The caveats of a must-use plugin itself makes handling that specific scenario a little tricky with what is currently available in the plugin. This can actually also occur when not a must-use plugin if switching between plugin versions with the plugin installer and never deactivating->manual update->activating the plugin. Quite rare and unlikely but I thought I would put it out there that this can occur as of this commit. Once a new queue system is introduced shortly it will not as we'll have new behavior that can prevent those types of edge cases related to that site transient and uncommon update sequences.