### PR TITLE
advanced-cache.php: use reasonable default location for constants.php.

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -4,8 +4,9 @@
  *
  * The advanced-cache.php creation method uses this during the disk setup and
  * requirements check. You can copy this file to the wp-content directory and edit
- * the $cache_enabler_constants_file value as needed. It will automatically delete
- * itself if stale or abandoned.
+ * the $cache_enabler_constants_file value as needed. If your web server supports it,
+ * you may also symlink this file into wp-content; no editing is needed in that case.
+ * The copy/symlink will automatically delete itself if stale or abandoned.
  *
  * @since   1.2.0
  * @change  1.8.6
@@ -15,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$cache_enabler_constants_file = '/your/path/to/wp-content/plugins/cache-enabler/constants.php';
+$cache_enabler_constants_file = realpath(__DIR__) . '/constants.php';
 
 if ( file_exists( $cache_enabler_constants_file ) ) {
     require $cache_enabler_constants_file;

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -293,8 +293,8 @@ final class Cache_Enabler_Disk {
         $advanced_cache_file          = WP_CONTENT_DIR . '/advanced-cache.php';
         $advanced_cache_file_contents = file_get_contents( $advanced_cache_sample_file );
 
-        $search  = '/your/path/to/wp-content/plugins/cache-enabler/constants.php';
-        $replace = CACHE_ENABLER_CONSTANTS_FILE;
+        $search  = "realpath(__DIR__) . '/constants.php'";
+        $replace = "'" . CACHE_ENABLER_CONSTANTS_FILE . "'";
 
         $advanced_cache_file_contents = str_replace( $search, $replace, $advanced_cache_file_contents );
         $advanced_cache_file_created  = file_put_contents( $advanced_cache_file, $advanced_cache_file_contents, LOCK_EX );


### PR DESCRIPTION
In advanced-cache.php, a variable `$cache_enabler_constants_file` is defined with a "junk" value that needs to be changed upon installation. If the wp-content directory is writable, then the cache-enabler activation routine will copy the included advanced-cache.php into it, modifying the junk value to point to the real location of constants.php.

If, however, wp-content is hardened to prevent writes to the plugins subdirectory [0], then the user has to copy advanced-cache.php into wp-content himself, and edit `$cache_enabler_constants_file manually`. To avoid this step, it would be nice if the user could simply symlink wp-content/advanced-cache.php to the sample copy provided by the plugin and have everything work "out of the box."

This commit replaces the junk default `$cache_enabler_constants_file` with one that allows said symlinking. Since the old value could never work, this should not be any worse for anyone's use case. The find/replace that the activation routine uses when wp-content *is* writable has also been updated and is a tiny bit uglier, but otherwise still works the same.

[0] https://wordpress.org/documentation/article/hardening-wordpress/