### PR TITLE
inc/cache_enabler_disk.class.php: remove all chmod() calls

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -354,13 +354,6 @@ final class Cache_Enabler_Disk {
         $new_cache_file_created = file_put_contents( $new_cache_file, $page_contents, LOCK_EX );
 
         if ( $new_cache_file_created !== false ) {
-            clearstatcache();
-            $new_cache_file_stats = @stat( $new_cache_file_dir );
-            $new_cache_file_perms = $new_cache_file_stats['mode'] & 0007777;
-            $new_cache_file_perms = $new_cache_file_perms & 0000666;
-            @chmod( $new_cache_file, $new_cache_file_perms );
-            clearstatcache();
-
             $page_created_url = self::get_cache_url( $new_cache_file_dir );
             $page_created_id  = url_to_postid( $page_created_url );
             $cache_created_index[ $new_cache_file_dir ]['url'] = $page_created_url;
@@ -1313,14 +1306,6 @@ final class Cache_Enabler_Disk {
 
         if ( ! wp_mkdir_p( $dir ) ) {
             return false;
-        }
-
-        if ( $fs->getchmod( $parent_dir ) !== $mode_string ) {
-            return $fs->chmod( $parent_dir, $mode_octal, true );
-        }
-
-        if ( $fs->getchmod( $dir ) !== $mode_string ) {
-            return $fs->chmod( $dir, $mode_octal );
         }
 
         return true;


### PR DESCRIPTION
Calling chmod() on newly-created files creates some problems that are discussed in depth in issue 320. Essentially, the plugin cannot know the access control mechanisms in use, and therefore cannot know what the "correct" permissions are. Two real consequences of this are,

  1. Running "chmod 755" grants more permissions than is desired on a system where the umask would make them 750.

  2. Changing the group bits breaks POSIX access control lists.

There are always better ways to address the problem of files being created with the wrong permissions, so this commit drops the calls to chmod() to undo the regression with respect to the above two items.

Closes: https://github.com/keycdn/cache-enabler/issues/320