### PR TITLE
Improve advanced cache file may be writable while directory may not

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -280,10 +280,6 @@ final class Cache_Enabler_Disk {
      */
     public static function create_advanced_cache_file() {
 
-        if ( ! is_writable( WP_CONTENT_DIR ) ) {
-            return false;
-        }
-
         $advanced_cache_sample_file = CACHE_ENABLER_DIR . '/advanced-cache.php';
 
         if ( ! is_readable( $advanced_cache_sample_file ) ) {


### PR DESCRIPTION
This pull request addresses an issue where the `advanced-cache.php` file is not created because `WP_CONTENT_DIR` is not writable by the PHP process.

The installation is based on Roots Bedrock. For security reasons, file ownership was set to `ubuntu:ubuntu`, and PHP runs as `www-data`. As a result of this architecture, the `create_advanced_cache_file` function returns false.

https://github.com/keycdn/cache-enabler/blob/efdae40df2f8931dc706fbd29fad84d650e8aa53/inc/cache_enabler_disk.class.php#L281-L286

Here’s a snapshot of the directory structure:

```sh
la /srv/wordpress/web/app
total 20
drwxrwxr-x  5 ubuntu ubuntu 4096 May  5 13:57 .
drwxrwxr-x  4 ubuntu ubuntu 4096 May  5 07:29 ..
lrwxrwxrwx  1 ubuntu ubuntu   49 May  5 13:57 advanced-cache.php -> ../../../storage/cache-enabler/advanced-cache.php
lrwxrwxrwx  1 ubuntu ubuntu   14 Jul 17  2023 cache -> ../../../cache
drwxrwxr-x  3 ubuntu ubuntu 4096 Apr  6  2023 mu-plugins
drwxrwxr-x 11 ubuntu ubuntu 4096 May  5 07:35 plugins
drwxrwxr-x  4 ubuntu ubuntu 4096 Jul 10  2023 themes
lrwxrwxrwx  1 ubuntu ubuntu   19 Jul 17  2023 uploads -> ../../../wp-uploads
```

In this setup, `WP_CONTENT_DIR` itself isn't writable by `www-data`, but the actual `advanced-cache.php` file is writable thanks to the symlink pointing to a directory owned by `www-data`.

Removing the above code block should have no consequences as the return value of the `file_put_contents` function is checked later on.