### PR TITLE
Update delete advanced cache when it is a symbolic link

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -52,7 +52,22 @@ final class Cache_Enabler_Disk {
         if ( ! is_dir( CACHE_ENABLER_SETTINGS_DIR ) ) {
             array_map( 'unlink', glob( WP_CONTENT_DIR . '/cache/cache-enabler-advcache-*.json' ) ); // < 1.4.0
             array_map( 'unlink', glob( ABSPATH . 'CE_SETTINGS_PATH-*.json' ) ); // = 1.4.0
-            @unlink( WP_CONTENT_DIR . '/advanced-cache.php' );
+
+            $file = WP_CONTENT_DIR . '/advanced-cache.php';
+
+            if ( ! is_link( $file )) {
+                @unlink( $file );
+            } else {
+                $target = readlink( $file );
+
+                $cwd = getcwd();
+                chdir( dirname( $file ) );
+
+                @unlink( realpath( $target ) );
+
+                chdir( $cwd );
+            }
+
             self::set_wp_cache_constant( false );
         }
     }


### PR DESCRIPTION
Please see #344 first.

If `advanced-cache.php` is a symlink, then the delete must be adjusted.