### PR TITLE
Improve cache or settings dir may already exist

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2367,6 +2367,7 @@ final class Cache_Enabler {
         foreach ( $dirs as $dir ) {
             $parent_dir = dirname( $dir );
             if (
+                ( file_exists( $dir ) && ! is_writable( $dir ) ) ||
                 ( file_exists( $parent_dir ) && ! is_writable( $parent_dir ) ) ||
                 ( ! file_exists( $parent_dir ) && ! is_writable( dirname($parent_dir) ) )
             ) {

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2367,9 +2367,11 @@ final class Cache_Enabler {
         foreach ( $dirs as $dir ) {
             $parent_dir = dirname( $dir );
             if (
-                ( file_exists( $dir ) && ! is_writable( $dir ) ) ||
-                ( file_exists( $parent_dir ) && ! is_writable( $parent_dir ) ) ||
-                ( ! file_exists( $parent_dir ) && ! is_writable( dirname($parent_dir) ) )
+                ( file_exists( $dir ) && ! is_writable( $dir ) && ! is_link( $dir ) ) || // dir exists but not writable and not a symlink
+                ( ! file_exists( $dir ) && (
+                    ( file_exists( $parent_dir ) && ! is_writable( $parent_dir ) ) || // parent exists but not writable
+                    ( ! file_exists( $parent_dir ) && ! is_writable( dirname( $parent_dir ) ) ) // parent doesn't exist, grandparent not writable
+                ) )
             ) {
                 printf(
                     '<div class="notice notice-warning"><p>%s</p></div>',


### PR DESCRIPTION
In some setups, the cache or settings directory may already exist on the server, which should normally be harmless. However, Cache Enabler flags this as an issue and displays the following persistent message in the WordPress dashboard:

```txt
Cache Enabler requires the directory %2$s to exist and be writable (mode 755, for example)
```

In my case, the cache directory is a symbolic link that PHP running as `www-data` does not have access to. As a result, when I disable the plugin, the cache symlink remains.

Here’s a snapshot of the directory structure:

```sh
la /srv/wordpress/web/app
total 20
drwxrwxr-x  5 ubuntu ubuntu 4096 May  5 13:57 .
drwxrwxr-x  4 ubuntu ubuntu 4096 May  5 07:29 ..
lrwxrwxrwx  1 ubuntu ubuntu   49 May  5 13:57 advanced-cache.php -> ../../../storage/cache-enabler/advanced-cache.php
lrwxrwxrwx  1 ubuntu ubuntu   14 Jul 17  2023 cache -> ../../../cache
drwxrwxr-x  3 ubuntu ubuntu 4096 Apr  6  2023 mu-plugins
drwxrwxr-x 11 ubuntu ubuntu 4096 May  5 07:35 plugins
drwxrwxr-x  4 ubuntu ubuntu 4096 Jul 10  2023 themes
lrwxrwxrwx  1 ubuntu ubuntu   19 Jul 17  2023 uploads -> ../../../wp-uploads
```
