### PR TITLE
Add clear cache action

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -2170,6 +2170,8 @@ final class Cache_Enabler {
         }
 
         Cache_Enabler_Disk::cache_iterator( $url, $args );
+
+        do_action( 'cleared_page_cache_by_url', $url );
     }
 
     /**


### PR DESCRIPTION
It's nice to have a way to be notified about the user clicking the clear cache button in the wordpress admin bar. In our specific case, we are sending that information further and logging it.